### PR TITLE
Individual configuration for fastest/longest and qualify/gold switching

### DIFF
--- a/Entities/UserSettings.cs
+++ b/Entities/UserSettings.cs
@@ -8,6 +8,7 @@
         public int OverlayColor { get; set; }
         public bool FlippedDisplay { get; set; }
         public bool SwitchBetweenLongest { get; set; }
+        public bool SwitchBetweenQualify { get; set; }
         public int CycleTimeSeconds { get; set; }
         public bool OverlayVisible { get; set; }
         public bool OverlayNotOnTop { get; set; }

--- a/Views/Overlay.cs
+++ b/Views/Overlay.cs
@@ -27,8 +27,6 @@ namespace FallGuysStats {
         private bool flippedImage;
         private int frameCount;
         private int labelToShow;
-        private int qualifyChanceLabel;
-        private int fastestLabel;
         private Sender NDISender;
         private VideoFrame NDIFrame;
         private Bitmap NDIImage, DrawImage, Background;
@@ -151,13 +149,9 @@ namespace FallGuysStats {
                         if (StatsForm.CurrentSettings.SwitchBetweenLongest) {
                             if ((frameCount % (StatsForm.CurrentSettings.CycleTimeSeconds * 20)) == 0) {
                                 labelToShow++;
-                                qualifyChanceLabel = ++qualifyChanceLabel % 2;
-                                fastestLabel = ++fastestLabel % (levelInfo.BestScore.HasValue ? 3 : 2);
                             }
                         } else {
                             labelToShow = 0;
-                            qualifyChanceLabel = 0;
-                            fastestLabel = 0;
                         }
 
                         this.Invoke((Action)UpdateInfo);
@@ -168,35 +162,6 @@ namespace FallGuysStats {
                 } catch { }
             }
         }
-
-        private void SetQualifyChanceLabel() {
-            switch (qualifyChanceLabel) {
-                case 0: 
-                    lblQualifyChance.Text = "QUALIFY:";
-                    float qualifyChance = (float)levelInfo.TotalQualify * 100f / (levelInfo.TotalPlays == 0 ? 1 : levelInfo.TotalPlays);
-                    lblQualifyChance.TextRight = $"{levelInfo.TotalQualify} / {levelInfo.TotalPlays} - {qualifyChance:0.0}%";
-                case 1: 
-                    lblQualifyChance.Text = "GOLD:";
-                    float qualifyChance = (float)levelInfo.TotalGolds * 100f / (levelInfo.TotalPlays == 0 ? 1 : levelInfo.TotalPlays);
-                    lblQualifyChance.TextRight = $"{levelInfo.TotalGolds} / {levelInfo.TotalPlays} - {qualifyChance:0.0}%";
-            }
-        }
-
-        private void SetFastestLabel() {
-            switch (qualifyChanceLabel) {
-                case 0: 
-                    lblFastest.Text = "FASTEST:";
-                    lblFastest.TextRight = levelInfo.BestFinish.HasValue ? $"{levelInfo.BestFinish:m\\:ss\\.ff}" : "-";
-                case 1: 
-                    lblFastest.Text = "LONGEST:";
-                    lblFastest.TextRight = levelInfo.LongestFinish.HasValue ? $"{levelInfo.LongestFinish:m\\:ss\\.ff}" : "-";
-                case 2: 
-                    lblFastest.Text = "HIGH SCORE:";
-                    lblFastest.TextRight = levelInfo.BestScore.Value.ToString();
-            }
-
-        }
-
         private void UpdateInfo() {
             if (StatsForm == null) { return; }
 
@@ -234,9 +199,27 @@ namespace FallGuysStats {
 
                     lblStreak.TextRight = $"{levelInfo.CurrentStreak} (BEST {levelInfo.BestStreak})";
 
-                    SetQualifyChanceLabel();
+                    if ((labelToShow % 2) == 0) {
+                        lblQualifyChance.Text = "QUALIFY:";
+                        float qualifyChance = (float)levelInfo.TotalQualify * 100f / (levelInfo.TotalPlays == 0 ? 1 : levelInfo.TotalPlays);
+                        lblQualifyChance.TextRight = $"{levelInfo.TotalQualify} / {levelInfo.TotalPlays} - {qualifyChance:0.0}%";
+                    } else {
+                        lblQualifyChance.Text = "GOLD:";
+                        float qualifyChance = (float)levelInfo.TotalGolds * 100f / (levelInfo.TotalPlays == 0 ? 1 : levelInfo.TotalPlays);
+                        lblQualifyChance.TextRight = $"{levelInfo.TotalGolds} / {levelInfo.TotalPlays} - {qualifyChance:0.0}%";
+                    }
 
-                    SetFastestLabel();
+                    int modCount = levelInfo.BestScore.HasValue ? 3 : 2;
+                    if ((labelToShow % modCount) == 1) {
+                        lblFastest.Text = "FASTEST:";
+                        lblFastest.TextRight = levelInfo.BestFinish.HasValue ? $"{levelInfo.BestFinish:m\\:ss\\.ff}" : "-";
+                    } else if ((labelToShow % modCount) == 2) {
+                        lblFastest.Text = "HIGH SCORE:";
+                        lblFastest.TextRight = levelInfo.BestScore.Value.ToString();
+                    } else {
+                        lblFastest.Text = "LONGEST:";
+                        lblFastest.TextRight = levelInfo.LongestFinish.HasValue ? $"{levelInfo.LongestFinish:m\\:ss\\.ff}" : "-";
+                    }
 
                     DateTime Start = lastRound.Start;
                     DateTime End = lastRound.End;

--- a/Views/Overlay.cs
+++ b/Views/Overlay.cs
@@ -27,6 +27,8 @@ namespace FallGuysStats {
         private bool flippedImage;
         private int frameCount;
         private int labelToShow;
+        private int qualifyChanceLabel;
+        private int fastestLabel;
         private Sender NDISender;
         private VideoFrame NDIFrame;
         private Bitmap NDIImage, DrawImage, Background;
@@ -149,9 +151,13 @@ namespace FallGuysStats {
                         if (StatsForm.CurrentSettings.SwitchBetweenLongest) {
                             if ((frameCount % (StatsForm.CurrentSettings.CycleTimeSeconds * 20)) == 0) {
                                 labelToShow++;
+                                qualifyChanceLabel = ++qualifyChanceLabel % 2;
+                                fastestLabel = ++fastestLabel % (levelInfo.BestScore.HasValue ? 3 : 2);
                             }
                         } else {
                             labelToShow = 0;
+                            qualifyChanceLabel = 0;
+                            fastestLabel = 0;
                         }
 
                         this.Invoke((Action)UpdateInfo);
@@ -162,6 +168,35 @@ namespace FallGuysStats {
                 } catch { }
             }
         }
+
+        private void SetQualifyChanceLabel() {
+            switch (qualifyChanceLabel) {
+                case 0: 
+                    lblQualifyChance.Text = "QUALIFY:";
+                    float qualifyChance = (float)levelInfo.TotalQualify * 100f / (levelInfo.TotalPlays == 0 ? 1 : levelInfo.TotalPlays);
+                    lblQualifyChance.TextRight = $"{levelInfo.TotalQualify} / {levelInfo.TotalPlays} - {qualifyChance:0.0}%";
+                case 1: 
+                    lblQualifyChance.Text = "GOLD:";
+                    float qualifyChance = (float)levelInfo.TotalGolds * 100f / (levelInfo.TotalPlays == 0 ? 1 : levelInfo.TotalPlays);
+                    lblQualifyChance.TextRight = $"{levelInfo.TotalGolds} / {levelInfo.TotalPlays} - {qualifyChance:0.0}%";
+            }
+        }
+
+        private void SetFastestLabel() {
+            switch (qualifyChanceLabel) {
+                case 0: 
+                    lblFastest.Text = "FASTEST:";
+                    lblFastest.TextRight = levelInfo.BestFinish.HasValue ? $"{levelInfo.BestFinish:m\\:ss\\.ff}" : "-";
+                case 1: 
+                    lblFastest.Text = "LONGEST:";
+                    lblFastest.TextRight = levelInfo.LongestFinish.HasValue ? $"{levelInfo.LongestFinish:m\\:ss\\.ff}" : "-";
+                case 2: 
+                    lblFastest.Text = "HIGH SCORE:";
+                    lblFastest.TextRight = levelInfo.BestScore.Value.ToString();
+            }
+
+        }
+
         private void UpdateInfo() {
             if (StatsForm == null) { return; }
 
@@ -199,27 +234,9 @@ namespace FallGuysStats {
 
                     lblStreak.TextRight = $"{levelInfo.CurrentStreak} (BEST {levelInfo.BestStreak})";
 
-                    if ((labelToShow % 2) == 0) {
-                        lblQualifyChance.Text = "QUALIFY:";
-                        float qualifyChance = (float)levelInfo.TotalQualify * 100f / (levelInfo.TotalPlays == 0 ? 1 : levelInfo.TotalPlays);
-                        lblQualifyChance.TextRight = $"{levelInfo.TotalQualify} / {levelInfo.TotalPlays} - {qualifyChance:0.0}%";
-                    } else {
-                        lblQualifyChance.Text = "GOLD:";
-                        float qualifyChance = (float)levelInfo.TotalGolds * 100f / (levelInfo.TotalPlays == 0 ? 1 : levelInfo.TotalPlays);
-                        lblQualifyChance.TextRight = $"{levelInfo.TotalGolds} / {levelInfo.TotalPlays} - {qualifyChance:0.0}%";
-                    }
+                    SetQualifyChanceLabel();
 
-                    int modCount = levelInfo.BestScore.HasValue ? 3 : 2;
-                    if ((labelToShow % modCount) == 1) {
-                        lblFastest.Text = "FASTEST:";
-                        lblFastest.TextRight = levelInfo.BestFinish.HasValue ? $"{levelInfo.BestFinish:m\\:ss\\.ff}" : "-";
-                    } else if ((labelToShow % modCount) == 2) {
-                        lblFastest.Text = "HIGH SCORE:";
-                        lblFastest.TextRight = levelInfo.BestScore.Value.ToString();
-                    } else {
-                        lblFastest.Text = "LONGEST:";
-                        lblFastest.TextRight = levelInfo.LongestFinish.HasValue ? $"{levelInfo.LongestFinish:m\\:ss\\.ff}" : "-";
-                    }
+                    SetFastestLabel();
 
                     DateTime Start = lastRound.Start;
                     DateTime End = lastRound.End;

--- a/Views/Settings.Designer.cs
+++ b/Views/Settings.Designer.cs
@@ -28,6 +28,7 @@
             this.lblLogPathNote = new System.Windows.Forms.Label();
             this.txtLogPath = new System.Windows.Forms.TextBox();
             this.btnSave = new System.Windows.Forms.Button();
+            this.chkCycleOverlayQualify = new System.Windows.Forms.CheckBox();
             this.chkCycleOverlayLongest = new System.Windows.Forms.CheckBox();
             this.grpOverlay = new System.Windows.Forms.GroupBox();
             this.cboOverlayColor = new System.Windows.Forms.ComboBox();
@@ -90,7 +91,7 @@
             // btnSave
             // 
             this.btnSave.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.btnSave.Location = new System.Drawing.Point(269, 326);
+            this.btnSave.Location = new System.Drawing.Point(269, 352);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(75, 23);
             this.btnSave.TabIndex = 5;
@@ -101,12 +102,22 @@
             // chkCycleOverlayLongest
             // 
             this.chkCycleOverlayLongest.AutoSize = true;
-            this.chkCycleOverlayLongest.Location = new System.Drawing.Point(15, 122);
+            this.chkCycleOverlayLongest.Location = new System.Drawing.Point(15, 148);
             this.chkCycleOverlayLongest.Name = "chkCycleOverlayLongest";
             this.chkCycleOverlayLongest.Size = new System.Drawing.Size(232, 17);
             this.chkCycleOverlayLongest.TabIndex = 4;
-            this.chkCycleOverlayLongest.Text = "Cycle Fastest / Longest and Qualify / Golds";
+            this.chkCycleOverlayLongest.Text = "Cycle Fastest / Longest";
             this.chkCycleOverlayLongest.UseVisualStyleBackColor = true;
+            // 
+            // chkCycleOverlayQualify
+            // 
+            this.chkCycleOverlayQualify.AutoSize = true;
+            this.chkCycleOverlayQualify.Location = new System.Drawing.Point(15, 122);
+            this.chkCycleOverlayQualify.Name = "chkCycleOverlayQualify";
+            this.chkCycleOverlayQualify.Size = new System.Drawing.Size(232, 17);
+            this.chkCycleOverlayQualify.TabIndex = 4;
+            this.chkCycleOverlayQualify.Text = "Cycle Qualify / Gold";
+            this.chkCycleOverlayQualify.UseVisualStyleBackColor = true;
             // 
             // grpOverlay
             // 
@@ -128,10 +139,11 @@
             this.grpOverlay.Controls.Add(this.lblCycleTimeSecondsTag);
             this.grpOverlay.Controls.Add(this.lblCycleTimeSeconds);
             this.grpOverlay.Controls.Add(this.txtCycleTimeSeconds);
+            this.grpOverlay.Controls.Add(this.chkCycleOverlayQualify);
             this.grpOverlay.Controls.Add(this.chkCycleOverlayLongest);
             this.grpOverlay.Location = new System.Drawing.Point(12, 114);
             this.grpOverlay.Name = "grpOverlay";
-            this.grpOverlay.Size = new System.Drawing.Size(590, 199);
+            this.grpOverlay.Size = new System.Drawing.Size(590, 225);
             this.grpOverlay.TabIndex = 4;
             this.grpOverlay.TabStop = false;
             this.grpOverlay.Text = "Overlay";
@@ -289,7 +301,7 @@
             // chkUseNDI
             // 
             this.chkUseNDI.AutoSize = true;
-            this.chkUseNDI.Location = new System.Drawing.Point(15, 169);
+            this.chkUseNDI.Location = new System.Drawing.Point(15, 200);
             this.chkUseNDI.Name = "chkUseNDI";
             this.chkUseNDI.Size = new System.Drawing.Size(234, 17);
             this.chkUseNDI.TabIndex = 8;
@@ -299,7 +311,7 @@
             // lblCycleTimeSecondsTag
             // 
             this.lblCycleTimeSecondsTag.AutoSize = true;
-            this.lblCycleTimeSecondsTag.Location = new System.Drawing.Point(140, 148);
+            this.lblCycleTimeSecondsTag.Location = new System.Drawing.Point(140, 174);
             this.lblCycleTimeSecondsTag.Name = "lblCycleTimeSecondsTag";
             this.lblCycleTimeSecondsTag.Size = new System.Drawing.Size(24, 13);
             this.lblCycleTimeSecondsTag.TabIndex = 7;
@@ -308,7 +320,7 @@
             // lblCycleTimeSeconds
             // 
             this.lblCycleTimeSeconds.AutoSize = true;
-            this.lblCycleTimeSeconds.Location = new System.Drawing.Point(34, 148);
+            this.lblCycleTimeSeconds.Location = new System.Drawing.Point(34, 174);
             this.lblCycleTimeSeconds.Name = "lblCycleTimeSeconds";
             this.lblCycleTimeSeconds.Size = new System.Drawing.Size(59, 13);
             this.lblCycleTimeSeconds.TabIndex = 5;
@@ -316,7 +328,7 @@
             // 
             // txtCycleTimeSeconds
             // 
-            this.txtCycleTimeSeconds.Location = new System.Drawing.Point(99, 145);
+            this.txtCycleTimeSeconds.Location = new System.Drawing.Point(99, 174);
             this.txtCycleTimeSeconds.MaxLength = 2;
             this.txtCycleTimeSeconds.Name = "txtCycleTimeSeconds";
             this.txtCycleTimeSeconds.Size = new System.Drawing.Size(35, 20);
@@ -394,7 +406,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(242)))), ((int)(((byte)(251)))));
-            this.ClientSize = new System.Drawing.Size(614, 361);
+            this.ClientSize = new System.Drawing.Size(614, 390);
             this.Controls.Add(this.grpOverlay);
             this.Controls.Add(this.grpStats);
             this.Controls.Add(this.btnSave);
@@ -426,6 +438,7 @@
         private System.Windows.Forms.Label lblLogPathNote;
         private System.Windows.Forms.TextBox txtLogPath;
         private System.Windows.Forms.Button btnSave;
+        private System.Windows.Forms.CheckBox chkCycleOverlayQualify;
         private System.Windows.Forms.CheckBox chkCycleOverlayLongest;
         private System.Windows.Forms.GroupBox grpOverlay;
         private System.Windows.Forms.Label lblCycleTimeSecondsTag;

--- a/Views/Settings.cs
+++ b/Views/Settings.cs
@@ -10,6 +10,7 @@ namespace FallGuysStats {
         private void Settings_Load(object sender, EventArgs e) {
             txtLogPath.Text = CurrentSettings.LogPath;
             chkCycleOverlayLongest.Checked = CurrentSettings.SwitchBetweenLongest;
+            chkCycleOverlayQualify.Checked = CurrentSettings.SwitchBetweenQualify;
             txtCycleTimeSeconds.Text = CurrentSettings.CycleTimeSeconds.ToString();
             txtPreviousWins.Text = CurrentSettings.PreviousWins.ToString();
             chkUseNDI.Checked = CurrentSettings.UseNDI;
@@ -77,6 +78,7 @@ namespace FallGuysStats {
             }
 
             CurrentSettings.SwitchBetweenLongest = chkCycleOverlayLongest.Checked;
+            CurrentSettings.SwitchBetweenQualify = chkCycleOverlayQualify.Checked;
             CurrentSettings.UseNDI = chkUseNDI.Checked;
             CurrentSettings.OverlayNotOnTop = !chkOverlayOnTop.Checked;
             if (chkHideRoundInfo.Checked && chkHideTimeInfo.Checked && chkHideWinsInfo.Checked) {

--- a/Views/Stats.cs
+++ b/Views/Stats.cs
@@ -167,6 +167,7 @@ namespace FallGuysStats {
                 OverlayLocationX = null,
                 OverlayLocationY = null,
                 SwitchBetweenLongest = true,
+                SwitchBetweenQualify = true,
                 OverlayVisible = false,
                 OverlayNotOnTop = false,
                 UseNDI = false,


### PR DESCRIPTION
I'm adding a checkbox in Settings window to individualize `fastest/longest` and `qualify/gold` switching configurations.

![image](https://user-images.githubusercontent.com/40670057/95006367-48f5a680-05da-11eb-8d48-002aac2b0b3b.png)

