### PR TITLE
Several Small Changes

### DIFF
--- a/Entities/UserSettings.cs
+++ b/Entities/UserSettings.cs
@@ -40,5 +40,8 @@
         public bool HideOverlayPercentages { get; set; }
         public bool HoopsieHeros { get; set; }
         public int Version { get; set; }
+        public bool IgnoreLevelTypeWhenSorting { get; set; }
+        public string GameExeLocation { get; set; }
+        public bool AutoLaunchGameOnStartup { get; set; }
     }
 }

--- a/Views/LevelDetails.cs
+++ b/Views/LevelDetails.cs
@@ -208,6 +208,8 @@ namespace FallGuysStats {
 
                         StatsForm.ResetStats();
                     }
+                } else if(e.KeyCode == Keys.Escape) {
+                    this.Close();
                 }
             } catch (Exception ex) {
                 MessageBox.Show(this, ex.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/Views/Settings.Designer.cs
+++ b/Views/Settings.Designer.cs
@@ -31,6 +31,14 @@
             this.chkCycleOverlayQualify = new System.Windows.Forms.CheckBox();
             this.chkCycleOverlayLongest = new System.Windows.Forms.CheckBox();
             this.grpOverlay = new System.Windows.Forms.GroupBox();
+            this.lblOrPing = new System.Windows.Forms.Label();
+            this.chkOnlyShowPing = new System.Windows.Forms.CheckBox();
+            this.lblOrFinal = new System.Windows.Forms.Label();
+            this.chkOnlyShowFinalStreak = new System.Windows.Forms.CheckBox();
+            this.lblOrLongest = new System.Windows.Forms.Label();
+            this.chkOnlyShowLongest = new System.Windows.Forms.CheckBox();
+            this.lblOrGold = new System.Windows.Forms.Label();
+            this.chkOnlyShowGold = new System.Windows.Forms.CheckBox();
             this.chkCycleOverlayStreak = new System.Windows.Forms.CheckBox();
             this.chkCycleOverlayPlayers = new System.Windows.Forms.CheckBox();
             this.chkHidePercentages = new System.Windows.Forms.CheckBox();
@@ -58,24 +66,28 @@
             this.lblPreviousWinsNote = new System.Windows.Forms.Label();
             this.lblPreviousWins = new System.Windows.Forms.Label();
             this.txtPreviousWins = new System.Windows.Forms.TextBox();
-            this.chkOnlyShowGold = new System.Windows.Forms.CheckBox();
-            this.lblOrGold = new System.Windows.Forms.Label();
-            this.lblOrLongest = new System.Windows.Forms.Label();
-            this.chkOnlyShowLongest = new System.Windows.Forms.CheckBox();
-            this.lblOrFinal = new System.Windows.Forms.Label();
-            this.chkOnlyShowFinalStreak = new System.Windows.Forms.CheckBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.chkOnlyShowPing = new System.Windows.Forms.CheckBox();
+            this.grpSortingOptions = new System.Windows.Forms.GroupBox();
+            this.chkIgnoreLevelTypeWhenSorting = new System.Windows.Forms.CheckBox();
+            this.grpGameOptions = new System.Windows.Forms.GroupBox();
+            this.fileSystemWatcher1 = new System.IO.FileSystemWatcher();
+            this.txtGameExeLocation = new System.Windows.Forms.TextBox();
+            this.btnGameExeLocationBrowse = new System.Windows.Forms.Button();
+            this.dlgGameExeBrowser = new System.Windows.Forms.OpenFileDialog();
+            this.chkAutoLaunchGameOnStart = new System.Windows.Forms.CheckBox();
             this.grpOverlay.SuspendLayout();
             this.grpStats.SuspendLayout();
+            this.grpGameOptions.SuspendLayout();
+            this.grpSortingOptions.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.fileSystemWatcher1)).BeginInit();
             this.SuspendLayout();
             // 
             // lblLogPath
             // 
             this.lblLogPath.AutoSize = true;
-            this.lblLogPath.Location = new System.Drawing.Point(8, 15);
+            this.lblLogPath.Location = new System.Drawing.Point(12, 23);
+            this.lblLogPath.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblLogPath.Name = "lblLogPath";
-            this.lblLogPath.Size = new System.Drawing.Size(50, 13);
+            this.lblLogPath.Size = new System.Drawing.Size(73, 20);
             this.lblLogPath.TabIndex = 0;
             this.lblLogPath.Text = "Log Path";
             // 
@@ -83,29 +95,32 @@
             // 
             this.lblLogPathNote.AutoSize = true;
             this.lblLogPathNote.ForeColor = System.Drawing.Color.DimGray;
-            this.lblLogPathNote.Location = new System.Drawing.Point(61, 35);
+            this.lblLogPathNote.Location = new System.Drawing.Point(92, 54);
+            this.lblLogPathNote.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblLogPathNote.Name = "lblLogPathNote";
-            this.lblLogPathNote.Size = new System.Drawing.Size(458, 13);
+            this.lblLogPathNote.Size = new System.Drawing.Size(682, 20);
             this.lblLogPathNote.TabIndex = 2;
             this.lblLogPathNote.Text = "* You should not need to set this. Only use when the program is not reading the c" +
-    "orrect location.";
+          "orrect location.";
             // 
             // txtLogPath
             // 
-            this.txtLogPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtLogPath.Location = new System.Drawing.Point(64, 12);
+            this.txtLogPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+                  | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtLogPath.Location = new System.Drawing.Point(96, 18);
+            this.txtLogPath.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtLogPath.Name = "txtLogPath";
-            this.txtLogPath.Size = new System.Drawing.Size(593, 20);
+            this.txtLogPath.Size = new System.Drawing.Size(888, 26);
             this.txtLogPath.TabIndex = 1;
             this.txtLogPath.Validating += new System.ComponentModel.CancelEventHandler(this.txtLogPath_Validating);
             // 
             // btnSave
             // 
             this.btnSave.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.btnSave.Location = new System.Drawing.Point(296, 417);
+            this.btnSave.Location = new System.Drawing.Point(444, 714);
+            this.btnSave.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnSave.Name = "btnSave";
-            this.btnSave.Size = new System.Drawing.Size(75, 23);
+            this.btnSave.Size = new System.Drawing.Size(112, 35);
             this.btnSave.TabIndex = 5;
             this.btnSave.Text = "Save";
             this.btnSave.UseVisualStyleBackColor = true;
@@ -114,9 +129,10 @@
             // chkCycleOverlayQualify
             // 
             this.chkCycleOverlayQualify.AutoSize = true;
-            this.chkCycleOverlayQualify.Location = new System.Drawing.Point(16, 188);
+            this.chkCycleOverlayQualify.Location = new System.Drawing.Point(24, 289);
+            this.chkCycleOverlayQualify.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkCycleOverlayQualify.Name = "chkCycleOverlayQualify";
-            this.chkCycleOverlayQualify.Size = new System.Drawing.Size(120, 17);
+            this.chkCycleOverlayQualify.Size = new System.Drawing.Size(171, 24);
             this.chkCycleOverlayQualify.TabIndex = 8;
             this.chkCycleOverlayQualify.Text = "Cycle Qualify / Gold";
             this.chkCycleOverlayQualify.UseVisualStyleBackColor = true;
@@ -125,9 +141,10 @@
             // chkCycleOverlayLongest
             // 
             this.chkCycleOverlayLongest.AutoSize = true;
-            this.chkCycleOverlayLongest.Location = new System.Drawing.Point(16, 211);
+            this.chkCycleOverlayLongest.Location = new System.Drawing.Point(24, 325);
+            this.chkCycleOverlayLongest.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkCycleOverlayLongest.Name = "chkCycleOverlayLongest";
-            this.chkCycleOverlayLongest.Size = new System.Drawing.Size(138, 17);
+            this.chkCycleOverlayLongest.Size = new System.Drawing.Size(201, 24);
             this.chkCycleOverlayLongest.TabIndex = 11;
             this.chkCycleOverlayLongest.Text = "Cycle Fastest / Longest";
             this.chkCycleOverlayLongest.UseVisualStyleBackColor = true;
@@ -135,10 +152,9 @@
             // 
             // grpOverlay
             // 
-            this.grpOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.grpOverlay.Controls.Add(this.label1);
+            this.grpOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+                  | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpOverlay.Controls.Add(this.lblOrPing);
             this.grpOverlay.Controls.Add(this.chkOnlyShowPing);
             this.grpOverlay.Controls.Add(this.lblOrFinal);
             this.grpOverlay.Controls.Add(this.chkOnlyShowFinalStreak);
@@ -169,19 +185,114 @@
             this.grpOverlay.Controls.Add(this.txtCycleTimeSeconds);
             this.grpOverlay.Controls.Add(this.chkCycleOverlayQualify);
             this.grpOverlay.Controls.Add(this.chkCycleOverlayLongest);
-            this.grpOverlay.Location = new System.Drawing.Point(12, 115);
+            this.grpOverlay.Location = new System.Drawing.Point(18, 177);
+            this.grpOverlay.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpOverlay.Name = "grpOverlay";
-            this.grpOverlay.Size = new System.Drawing.Size(645, 290);
+            this.grpOverlay.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpOverlay.Size = new System.Drawing.Size(968, 436);
             this.grpOverlay.TabIndex = 4;
             this.grpOverlay.TabStop = false;
             this.grpOverlay.Text = "Overlay";
             // 
+            // lblOrPing
+            // 
+            this.lblOrPing.AutoSize = true;
+            this.lblOrPing.ForeColor = System.Drawing.Color.DimGray;
+            this.lblOrPing.Location = new System.Drawing.Point(240, 397);
+            this.lblOrPing.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblOrPing.Name = "lblOrPing";
+            this.lblOrPing.Size = new System.Drawing.Size(23, 20);
+            this.lblOrPing.TabIndex = 18;
+            this.lblOrPing.Text = "or";
+            // 
+            // chkOnlyShowPing
+            // 
+            this.chkOnlyShowPing.AutoSize = true;
+            this.chkOnlyShowPing.Location = new System.Drawing.Point(290, 395);
+            this.chkOnlyShowPing.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.chkOnlyShowPing.Name = "chkOnlyShowPing";
+            this.chkOnlyShowPing.Size = new System.Drawing.Size(145, 24);
+            this.chkOnlyShowPing.TabIndex = 19;
+            this.chkOnlyShowPing.Text = "Only Show Ping";
+            this.chkOnlyShowPing.UseVisualStyleBackColor = true;
+            this.chkOnlyShowPing.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+            // 
+            // lblOrFinal
+            // 
+            this.lblOrFinal.AutoSize = true;
+            this.lblOrFinal.ForeColor = System.Drawing.Color.DimGray;
+            this.lblOrFinal.Location = new System.Drawing.Point(240, 362);
+            this.lblOrFinal.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblOrFinal.Name = "lblOrFinal";
+            this.lblOrFinal.Size = new System.Drawing.Size(23, 20);
+            this.lblOrFinal.TabIndex = 15;
+            this.lblOrFinal.Text = "or";
+            // 
+            // chkOnlyShowFinalStreak
+            // 
+            this.chkOnlyShowFinalStreak.AutoSize = true;
+            this.chkOnlyShowFinalStreak.Location = new System.Drawing.Point(290, 360);
+            this.chkOnlyShowFinalStreak.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.chkOnlyShowFinalStreak.Name = "chkOnlyShowFinalStreak";
+            this.chkOnlyShowFinalStreak.Size = new System.Drawing.Size(199, 24);
+            this.chkOnlyShowFinalStreak.TabIndex = 16;
+            this.chkOnlyShowFinalStreak.Text = "Only Show Final Streak";
+            this.chkOnlyShowFinalStreak.UseVisualStyleBackColor = true;
+            this.chkOnlyShowFinalStreak.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+            // 
+            // lblOrLongest
+            // 
+            this.lblOrLongest.AutoSize = true;
+            this.lblOrLongest.ForeColor = System.Drawing.Color.DimGray;
+            this.lblOrLongest.Location = new System.Drawing.Point(240, 326);
+            this.lblOrLongest.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblOrLongest.Name = "lblOrLongest";
+            this.lblOrLongest.Size = new System.Drawing.Size(23, 20);
+            this.lblOrLongest.TabIndex = 12;
+            this.lblOrLongest.Text = "or";
+            // 
+            // chkOnlyShowLongest
+            // 
+            this.chkOnlyShowLongest.AutoSize = true;
+            this.chkOnlyShowLongest.Location = new System.Drawing.Point(290, 325);
+            this.chkOnlyShowLongest.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.chkOnlyShowLongest.Name = "chkOnlyShowLongest";
+            this.chkOnlyShowLongest.Size = new System.Drawing.Size(172, 24);
+            this.chkOnlyShowLongest.TabIndex = 13;
+            this.chkOnlyShowLongest.Text = "Only Show Longest";
+            this.chkOnlyShowLongest.UseVisualStyleBackColor = true;
+            this.chkOnlyShowLongest.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+            // 
+            // lblOrGold
+            // 
+            this.lblOrGold.AutoSize = true;
+            this.lblOrGold.ForeColor = System.Drawing.Color.DimGray;
+            this.lblOrGold.Location = new System.Drawing.Point(240, 291);
+            this.lblOrGold.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblOrGold.Name = "lblOrGold";
+            this.lblOrGold.Size = new System.Drawing.Size(23, 20);
+            this.lblOrGold.TabIndex = 9;
+            this.lblOrGold.Text = "or";
+            // 
+            // chkOnlyShowGold
+            // 
+            this.chkOnlyShowGold.AutoSize = true;
+            this.chkOnlyShowGold.Location = new System.Drawing.Point(290, 289);
+            this.chkOnlyShowGold.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.chkOnlyShowGold.Name = "chkOnlyShowGold";
+            this.chkOnlyShowGold.Size = new System.Drawing.Size(148, 24);
+            this.chkOnlyShowGold.TabIndex = 10;
+            this.chkOnlyShowGold.Text = "Only Show Gold";
+            this.chkOnlyShowGold.UseVisualStyleBackColor = true;
+            this.chkOnlyShowGold.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+            // 
             // chkCycleOverlayStreak
             // 
             this.chkCycleOverlayStreak.AutoSize = true;
-            this.chkCycleOverlayStreak.Location = new System.Drawing.Point(16, 234);
+            this.chkCycleOverlayStreak.Location = new System.Drawing.Point(24, 360);
+            this.chkCycleOverlayStreak.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkCycleOverlayStreak.Name = "chkCycleOverlayStreak";
-            this.chkCycleOverlayStreak.Size = new System.Drawing.Size(141, 17);
+            this.chkCycleOverlayStreak.Size = new System.Drawing.Size(201, 24);
             this.chkCycleOverlayStreak.TabIndex = 14;
             this.chkCycleOverlayStreak.Text = "Cycle Win / Final Streak";
             this.chkCycleOverlayStreak.UseVisualStyleBackColor = true;
@@ -190,9 +301,10 @@
             // chkCycleOverlayPlayers
             // 
             this.chkCycleOverlayPlayers.AutoSize = true;
-            this.chkCycleOverlayPlayers.Location = new System.Drawing.Point(16, 257);
+            this.chkCycleOverlayPlayers.Location = new System.Drawing.Point(24, 395);
+            this.chkCycleOverlayPlayers.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkCycleOverlayPlayers.Name = "chkCycleOverlayPlayers";
-            this.chkCycleOverlayPlayers.Size = new System.Drawing.Size(121, 17);
+            this.chkCycleOverlayPlayers.Size = new System.Drawing.Size(171, 24);
             this.chkCycleOverlayPlayers.TabIndex = 17;
             this.chkCycleOverlayPlayers.Text = "Cycle Players / Ping";
             this.chkCycleOverlayPlayers.UseVisualStyleBackColor = true;
@@ -201,9 +313,10 @@
             // chkHidePercentages
             // 
             this.chkHidePercentages.AutoSize = true;
-            this.chkHidePercentages.Location = new System.Drawing.Point(16, 90);
+            this.chkHidePercentages.Location = new System.Drawing.Point(24, 138);
+            this.chkHidePercentages.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkHidePercentages.Name = "chkHidePercentages";
-            this.chkHidePercentages.Size = new System.Drawing.Size(111, 17);
+            this.chkHidePercentages.Size = new System.Drawing.Size(162, 24);
             this.chkHidePercentages.TabIndex = 3;
             this.chkHidePercentages.Text = "Hide Percentages";
             this.chkHidePercentages.UseVisualStyleBackColor = true;
@@ -211,9 +324,10 @@
             // chkHideWinsInfo
             // 
             this.chkHideWinsInfo.AutoSize = true;
-            this.chkHideWinsInfo.Location = new System.Drawing.Point(16, 21);
+            this.chkHideWinsInfo.Location = new System.Drawing.Point(24, 32);
+            this.chkHideWinsInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkHideWinsInfo.Name = "chkHideWinsInfo";
-            this.chkHideWinsInfo.Size = new System.Drawing.Size(95, 17);
+            this.chkHideWinsInfo.Size = new System.Drawing.Size(137, 24);
             this.chkHideWinsInfo.TabIndex = 0;
             this.chkHideWinsInfo.Text = "Hide Wins info";
             this.chkHideWinsInfo.UseVisualStyleBackColor = true;
@@ -229,26 +343,29 @@
             "Green",
             "Blue",
             "Black"});
-            this.cboOverlayColor.Location = new System.Drawing.Point(447, 157);
+            this.cboOverlayColor.Location = new System.Drawing.Point(670, 242);
+            this.cboOverlayColor.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cboOverlayColor.Name = "cboOverlayColor";
-            this.cboOverlayColor.Size = new System.Drawing.Size(183, 21);
+            this.cboOverlayColor.Size = new System.Drawing.Size(272, 28);
             this.cboOverlayColor.TabIndex = 27;
             // 
             // lblOverlayColor
             // 
             this.lblOverlayColor.AutoSize = true;
-            this.lblOverlayColor.Location = new System.Drawing.Point(376, 160);
+            this.lblOverlayColor.Location = new System.Drawing.Point(564, 246);
+            this.lblOverlayColor.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblOverlayColor.Name = "lblOverlayColor";
-            this.lblOverlayColor.Size = new System.Drawing.Size(65, 13);
+            this.lblOverlayColor.Size = new System.Drawing.Size(95, 20);
             this.lblOverlayColor.TabIndex = 26;
             this.lblOverlayColor.Text = "Background";
             // 
             // chkFlipped
             // 
             this.chkFlipped.AutoSize = true;
-            this.chkFlipped.Location = new System.Drawing.Point(447, 188);
+            this.chkFlipped.Location = new System.Drawing.Point(670, 289);
+            this.chkFlipped.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkFlipped.Name = "chkFlipped";
-            this.chkFlipped.Size = new System.Drawing.Size(132, 17);
+            this.chkFlipped.Size = new System.Drawing.Size(195, 24);
             this.chkFlipped.TabIndex = 28;
             this.chkFlipped.Text = "Flip display horizontally";
             this.chkFlipped.UseVisualStyleBackColor = true;
@@ -256,9 +373,10 @@
             // chkShowTabs
             // 
             this.chkShowTabs.AutoSize = true;
-            this.chkShowTabs.Location = new System.Drawing.Point(16, 113);
+            this.chkShowTabs.Location = new System.Drawing.Point(24, 174);
+            this.chkShowTabs.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkShowTabs.Name = "chkShowTabs";
-            this.chkShowTabs.Size = new System.Drawing.Size(148, 17);
+            this.chkShowTabs.Size = new System.Drawing.Size(217, 24);
             this.chkShowTabs.TabIndex = 4;
             this.chkShowTabs.Text = "Show Tab for current filter";
             this.chkShowTabs.UseVisualStyleBackColor = true;
@@ -266,9 +384,10 @@
             // chkHideTimeInfo
             // 
             this.chkHideTimeInfo.AutoSize = true;
-            this.chkHideTimeInfo.Location = new System.Drawing.Point(16, 67);
+            this.chkHideTimeInfo.Location = new System.Drawing.Point(24, 103);
+            this.chkHideTimeInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkHideTimeInfo.Name = "chkHideTimeInfo";
-            this.chkHideTimeInfo.Size = new System.Drawing.Size(94, 17);
+            this.chkHideTimeInfo.Size = new System.Drawing.Size(136, 24);
             this.chkHideTimeInfo.TabIndex = 2;
             this.chkHideTimeInfo.Text = "Hide Time info";
             this.chkHideTimeInfo.UseVisualStyleBackColor = true;
@@ -276,9 +395,10 @@
             // chkHideRoundInfo
             // 
             this.chkHideRoundInfo.AutoSize = true;
-            this.chkHideRoundInfo.Location = new System.Drawing.Point(16, 44);
+            this.chkHideRoundInfo.Location = new System.Drawing.Point(24, 68);
+            this.chkHideRoundInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkHideRoundInfo.Name = "chkHideRoundInfo";
-            this.chkHideRoundInfo.Size = new System.Drawing.Size(103, 17);
+            this.chkHideRoundInfo.Size = new System.Drawing.Size(150, 24);
             this.chkHideRoundInfo.TabIndex = 1;
             this.chkHideRoundInfo.Text = "Hide Round info";
             this.chkHideRoundInfo.UseVisualStyleBackColor = true;
@@ -294,17 +414,19 @@
             "Week Stats",
             "Day Stats",
             "Session Stats"});
-            this.cboFastestFilter.Location = new System.Drawing.Point(447, 69);
+            this.cboFastestFilter.Location = new System.Drawing.Point(670, 106);
+            this.cboFastestFilter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cboFastestFilter.Name = "cboFastestFilter";
-            this.cboFastestFilter.Size = new System.Drawing.Size(183, 21);
+            this.cboFastestFilter.Size = new System.Drawing.Size(272, 28);
             this.cboFastestFilter.TabIndex = 25;
             // 
             // lblFastestFilter
             // 
             this.lblFastestFilter.AutoSize = true;
-            this.lblFastestFilter.Location = new System.Drawing.Point(326, 72);
+            this.lblFastestFilter.Location = new System.Drawing.Point(489, 111);
+            this.lblFastestFilter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblFastestFilter.Name = "lblFastestFilter";
-            this.lblFastestFilter.Size = new System.Drawing.Size(115, 13);
+            this.lblFastestFilter.Size = new System.Drawing.Size(172, 20);
             this.lblFastestFilter.TabIndex = 24;
             this.lblFastestFilter.Text = "Fastest / Longest Filter";
             // 
@@ -319,17 +441,19 @@
             "Week Stats",
             "Day Stats",
             "Session Stats"});
-            this.cboQualifyFilter.Location = new System.Drawing.Point(447, 44);
+            this.cboQualifyFilter.Location = new System.Drawing.Point(670, 68);
+            this.cboQualifyFilter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cboQualifyFilter.Name = "cboQualifyFilter";
-            this.cboQualifyFilter.Size = new System.Drawing.Size(183, 21);
+            this.cboQualifyFilter.Size = new System.Drawing.Size(272, 28);
             this.cboQualifyFilter.TabIndex = 23;
             // 
             // lblQualifyFilter
             // 
             this.lblQualifyFilter.AutoSize = true;
-            this.lblQualifyFilter.Location = new System.Drawing.Point(344, 47);
+            this.lblQualifyFilter.Location = new System.Drawing.Point(516, 72);
+            this.lblQualifyFilter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblQualifyFilter.Name = "lblQualifyFilter";
-            this.lblQualifyFilter.Size = new System.Drawing.Size(97, 13);
+            this.lblQualifyFilter.Size = new System.Drawing.Size(142, 20);
             this.lblQualifyFilter.TabIndex = 22;
             this.lblQualifyFilter.Text = "Qualify / Gold Filter";
             // 
@@ -344,26 +468,29 @@
             "Week Stats",
             "Day Stats",
             "Session Stats"});
-            this.cboWinsFilter.Location = new System.Drawing.Point(447, 19);
+            this.cboWinsFilter.Location = new System.Drawing.Point(670, 29);
+            this.cboWinsFilter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cboWinsFilter.Name = "cboWinsFilter";
-            this.cboWinsFilter.Size = new System.Drawing.Size(183, 21);
+            this.cboWinsFilter.Size = new System.Drawing.Size(272, 28);
             this.cboWinsFilter.TabIndex = 21;
             // 
             // lblWinsFilter
             // 
             this.lblWinsFilter.AutoSize = true;
-            this.lblWinsFilter.Location = new System.Drawing.Point(352, 22);
+            this.lblWinsFilter.Location = new System.Drawing.Point(528, 34);
+            this.lblWinsFilter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblWinsFilter.Name = "lblWinsFilter";
-            this.lblWinsFilter.Size = new System.Drawing.Size(89, 13);
+            this.lblWinsFilter.Size = new System.Drawing.Size(129, 20);
             this.lblWinsFilter.TabIndex = 20;
             this.lblWinsFilter.Text = "Wins / Final Filter";
             // 
             // chkOverlayOnTop
             // 
             this.chkOverlayOnTop.AutoSize = true;
-            this.chkOverlayOnTop.Location = new System.Drawing.Point(447, 211);
+            this.chkOverlayOnTop.Location = new System.Drawing.Point(670, 325);
+            this.chkOverlayOnTop.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkOverlayOnTop.Name = "chkOverlayOnTop";
-            this.chkOverlayOnTop.Size = new System.Drawing.Size(120, 17);
+            this.chkOverlayOnTop.Size = new System.Drawing.Size(174, 24);
             this.chkOverlayOnTop.TabIndex = 29;
             this.chkOverlayOnTop.Text = "Always show on top";
             this.chkOverlayOnTop.UseVisualStyleBackColor = true;
@@ -371,9 +498,10 @@
             // chkUseNDI
             // 
             this.chkUseNDI.AutoSize = true;
-            this.chkUseNDI.Location = new System.Drawing.Point(447, 234);
+            this.chkUseNDI.Location = new System.Drawing.Point(670, 360);
+            this.chkUseNDI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkUseNDI.Name = "chkUseNDI";
-            this.chkUseNDI.Size = new System.Drawing.Size(157, 17);
+            this.chkUseNDI.Size = new System.Drawing.Size(231, 24);
             this.chkUseNDI.TabIndex = 30;
             this.chkUseNDI.Text = "Use NDI to transmit Overlay";
             this.chkUseNDI.UseVisualStyleBackColor = true;
@@ -381,27 +509,30 @@
             // lblCycleTimeSecondsTag
             // 
             this.lblCycleTimeSecondsTag.AutoSize = true;
-            this.lblCycleTimeSecondsTag.Location = new System.Drawing.Point(125, 160);
+            this.lblCycleTimeSecondsTag.Location = new System.Drawing.Point(188, 246);
+            this.lblCycleTimeSecondsTag.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblCycleTimeSecondsTag.Name = "lblCycleTimeSecondsTag";
-            this.lblCycleTimeSecondsTag.Size = new System.Drawing.Size(24, 13);
+            this.lblCycleTimeSecondsTag.Size = new System.Drawing.Size(34, 20);
             this.lblCycleTimeSecondsTag.TabIndex = 7;
             this.lblCycleTimeSecondsTag.Text = "sec";
             // 
             // lblCycleTimeSeconds
             // 
             this.lblCycleTimeSeconds.AutoSize = true;
-            this.lblCycleTimeSeconds.Location = new System.Drawing.Point(19, 160);
+            this.lblCycleTimeSeconds.Location = new System.Drawing.Point(28, 246);
+            this.lblCycleTimeSeconds.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblCycleTimeSeconds.Name = "lblCycleTimeSeconds";
-            this.lblCycleTimeSeconds.Size = new System.Drawing.Size(59, 13);
+            this.lblCycleTimeSeconds.Size = new System.Drawing.Size(85, 20);
             this.lblCycleTimeSeconds.TabIndex = 5;
             this.lblCycleTimeSeconds.Text = "Cycle Time";
             // 
             // txtCycleTimeSeconds
             // 
-            this.txtCycleTimeSeconds.Location = new System.Drawing.Point(84, 157);
+            this.txtCycleTimeSeconds.Location = new System.Drawing.Point(126, 242);
+            this.txtCycleTimeSeconds.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtCycleTimeSeconds.MaxLength = 2;
             this.txtCycleTimeSeconds.Name = "txtCycleTimeSeconds";
-            this.txtCycleTimeSeconds.Size = new System.Drawing.Size(35, 20);
+            this.txtCycleTimeSeconds.Size = new System.Drawing.Size(50, 26);
             this.txtCycleTimeSeconds.TabIndex = 6;
             this.txtCycleTimeSeconds.Text = "5";
             this.txtCycleTimeSeconds.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
@@ -409,16 +540,18 @@
             // 
             // grpStats
             // 
-            this.grpStats.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpStats.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+                  | System.Windows.Forms.AnchorStyles.Right)));
             this.grpStats.Controls.Add(this.chkChangeHoopsieLegends);
             this.grpStats.Controls.Add(this.chkAutoUpdate);
             this.grpStats.Controls.Add(this.lblPreviousWinsNote);
             this.grpStats.Controls.Add(this.lblPreviousWins);
             this.grpStats.Controls.Add(this.txtPreviousWins);
-            this.grpStats.Location = new System.Drawing.Point(12, 58);
+            this.grpStats.Location = new System.Drawing.Point(18, 89);
+            this.grpStats.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.grpStats.Name = "grpStats";
-            this.grpStats.Size = new System.Drawing.Size(645, 51);
+            this.grpStats.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.grpStats.Size = new System.Drawing.Size(968, 78);
             this.grpStats.TabIndex = 3;
             this.grpStats.TabStop = false;
             this.grpStats.Text = "Stats";
@@ -426,9 +559,10 @@
             // chkChangeHoopsieLegends
             // 
             this.chkChangeHoopsieLegends.AutoSize = true;
-            this.chkChangeHoopsieLegends.Location = new System.Drawing.Point(390, 21);
+            this.chkChangeHoopsieLegends.Location = new System.Drawing.Point(585, 32);
+            this.chkChangeHoopsieLegends.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkChangeHoopsieLegends.Name = "chkChangeHoopsieLegends";
-            this.chkChangeHoopsieLegends.Size = new System.Drawing.Size(243, 17);
+            this.chkChangeHoopsieLegends.Size = new System.Drawing.Size(362, 24);
             this.chkChangeHoopsieLegends.TabIndex = 4;
             this.chkChangeHoopsieLegends.Text = "Rename Hoopsie Legends to Hoopsie Heroes";
             this.chkChangeHoopsieLegends.UseVisualStyleBackColor = true;
@@ -436,9 +570,10 @@
             // chkAutoUpdate
             // 
             this.chkAutoUpdate.AutoSize = true;
-            this.chkAutoUpdate.Location = new System.Drawing.Point(254, 21);
+            this.chkAutoUpdate.Location = new System.Drawing.Point(381, 32);
+            this.chkAutoUpdate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.chkAutoUpdate.Name = "chkAutoUpdate";
-            this.chkAutoUpdate.Size = new System.Drawing.Size(128, 17);
+            this.chkAutoUpdate.Size = new System.Drawing.Size(190, 24);
             this.chkAutoUpdate.TabIndex = 3;
             this.chkAutoUpdate.Text = "Auto Update Program";
             this.chkAutoUpdate.UseVisualStyleBackColor = true;
@@ -447,123 +582,65 @@
             // 
             this.lblPreviousWinsNote.AutoSize = true;
             this.lblPreviousWinsNote.ForeColor = System.Drawing.Color.DimGray;
-            this.lblPreviousWinsNote.Location = new System.Drawing.Point(133, 22);
+            this.lblPreviousWinsNote.Location = new System.Drawing.Point(200, 34);
+            this.lblPreviousWinsNote.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblPreviousWinsNote.Name = "lblPreviousWinsNote";
-            this.lblPreviousWinsNote.Size = new System.Drawing.Size(108, 13);
+            this.lblPreviousWinsNote.Size = new System.Drawing.Size(162, 20);
             this.lblPreviousWinsNote.TabIndex = 2;
             this.lblPreviousWinsNote.Text = "(Before using tracker)";
             // 
             // lblPreviousWins
             // 
             this.lblPreviousWins.AutoSize = true;
-            this.lblPreviousWins.Location = new System.Drawing.Point(11, 22);
+            this.lblPreviousWins.Location = new System.Drawing.Point(16, 34);
+            this.lblPreviousWins.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblPreviousWins.Name = "lblPreviousWins";
-            this.lblPreviousWins.Size = new System.Drawing.Size(75, 13);
+            this.lblPreviousWins.Size = new System.Drawing.Size(108, 20);
             this.lblPreviousWins.TabIndex = 0;
             this.lblPreviousWins.Text = "Previous Wins";
             // 
             // txtPreviousWins
             // 
-            this.txtPreviousWins.Location = new System.Drawing.Point(92, 19);
+            this.txtPreviousWins.Location = new System.Drawing.Point(138, 29);
+            this.txtPreviousWins.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.txtPreviousWins.MaxLength = 4;
             this.txtPreviousWins.Name = "txtPreviousWins";
-            this.txtPreviousWins.Size = new System.Drawing.Size(35, 20);
+            this.txtPreviousWins.Size = new System.Drawing.Size(50, 26);
             this.txtPreviousWins.TabIndex = 1;
             this.txtPreviousWins.Text = "0";
             this.txtPreviousWins.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.txtPreviousWins.Validating += new System.ComponentModel.CancelEventHandler(this.txtPreviousWins_Validating);
             // 
-            // chkOnlyShowGold
+            // grpSortingOptions
             // 
-            this.chkOnlyShowGold.AutoSize = true;
-            this.chkOnlyShowGold.Location = new System.Drawing.Point(193, 188);
-            this.chkOnlyShowGold.Name = "chkOnlyShowGold";
-            this.chkOnlyShowGold.Size = new System.Drawing.Size(102, 17);
-            this.chkOnlyShowGold.TabIndex = 10;
-            this.chkOnlyShowGold.Text = "Only Show Gold";
-            this.chkOnlyShowGold.UseVisualStyleBackColor = true;
-            this.chkOnlyShowGold.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+            this.grpSortingOptions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+                  | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpSortingOptions.Controls.Add(this.chkIgnoreLevelTypeWhenSorting);
+            this.grpSortingOptions.Location = new System.Drawing.Point(18, 625);
+            this.grpSortingOptions.Name = "grpSortingOptions";
+            this.grpSortingOptions.Size = new System.Drawing.Size(968, 66);
+            this.grpSortingOptions.TabIndex = 6;
+            this.grpSortingOptions.TabStop = false;
+            this.grpSortingOptions.Text = "Sorting Options";
             // 
-            // lblOrGold
+            // chkIgnoreLevelTypeWhenSorting
             // 
-            this.lblOrGold.AutoSize = true;
-            this.lblOrGold.ForeColor = System.Drawing.Color.DimGray;
-            this.lblOrGold.Location = new System.Drawing.Point(160, 189);
-            this.lblOrGold.Name = "lblOrGold";
-            this.lblOrGold.Size = new System.Drawing.Size(16, 13);
-            this.lblOrGold.TabIndex = 9;
-            this.lblOrGold.Text = "or";
-            // 
-            // lblOrLongest
-            // 
-            this.lblOrLongest.AutoSize = true;
-            this.lblOrLongest.ForeColor = System.Drawing.Color.DimGray;
-            this.lblOrLongest.Location = new System.Drawing.Point(160, 212);
-            this.lblOrLongest.Name = "lblOrLongest";
-            this.lblOrLongest.Size = new System.Drawing.Size(16, 13);
-            this.lblOrLongest.TabIndex = 12;
-            this.lblOrLongest.Text = "or";
-            // 
-            // chkOnlyShowLongest
-            // 
-            this.chkOnlyShowLongest.AutoSize = true;
-            this.chkOnlyShowLongest.Location = new System.Drawing.Point(193, 211);
-            this.chkOnlyShowLongest.Name = "chkOnlyShowLongest";
-            this.chkOnlyShowLongest.Size = new System.Drawing.Size(118, 17);
-            this.chkOnlyShowLongest.TabIndex = 13;
-            this.chkOnlyShowLongest.Text = "Only Show Longest";
-            this.chkOnlyShowLongest.UseVisualStyleBackColor = true;
-            this.chkOnlyShowLongest.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
-            // 
-            // lblOrFinal
-            // 
-            this.lblOrFinal.AutoSize = true;
-            this.lblOrFinal.ForeColor = System.Drawing.Color.DimGray;
-            this.lblOrFinal.Location = new System.Drawing.Point(160, 235);
-            this.lblOrFinal.Name = "lblOrFinal";
-            this.lblOrFinal.Size = new System.Drawing.Size(16, 13);
-            this.lblOrFinal.TabIndex = 15;
-            this.lblOrFinal.Text = "or";
-            // 
-            // chkOnlyShowFinalStreak
-            // 
-            this.chkOnlyShowFinalStreak.AutoSize = true;
-            this.chkOnlyShowFinalStreak.Location = new System.Drawing.Point(193, 234);
-            this.chkOnlyShowFinalStreak.Name = "chkOnlyShowFinalStreak";
-            this.chkOnlyShowFinalStreak.Size = new System.Drawing.Size(136, 17);
-            this.chkOnlyShowFinalStreak.TabIndex = 16;
-            this.chkOnlyShowFinalStreak.Text = "Only Show Final Streak";
-            this.chkOnlyShowFinalStreak.UseVisualStyleBackColor = true;
-            this.chkOnlyShowFinalStreak.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.ForeColor = System.Drawing.Color.DimGray;
-            this.label1.Location = new System.Drawing.Point(160, 258);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(16, 13);
-            this.label1.TabIndex = 18;
-            this.label1.Text = "or";
-            // 
-            // chkOnlyShowPing
-            // 
-            this.chkOnlyShowPing.AutoSize = true;
-            this.chkOnlyShowPing.Location = new System.Drawing.Point(193, 257);
-            this.chkOnlyShowPing.Name = "chkOnlyShowPing";
-            this.chkOnlyShowPing.Size = new System.Drawing.Size(101, 17);
-            this.chkOnlyShowPing.TabIndex = 19;
-            this.chkOnlyShowPing.Text = "Only Show Ping";
-            this.chkOnlyShowPing.UseVisualStyleBackColor = true;
-            this.chkOnlyShowPing.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+            this.chkIgnoreLevelTypeWhenSorting.AutoSize = true;
+            this.chkIgnoreLevelTypeWhenSorting.Location = new System.Drawing.Point(24, 26);
+            this.chkIgnoreLevelTypeWhenSorting.Name = "chkIgnoreLevelTypeWhenSorting";
+            this.chkIgnoreLevelTypeWhenSorting.Size = new System.Drawing.Size(254, 24);
+            this.chkIgnoreLevelTypeWhenSorting.TabIndex = 0;
+            this.chkIgnoreLevelTypeWhenSorting.Text = "Ignore Level Type when sorting";
+            this.chkIgnoreLevelTypeWhenSorting.UseVisualStyleBackColor = true;
             // 
             // Settings
             // 
             this.AcceptButton = this.btnSave;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(242)))), ((int)(((byte)(251)))));
-            this.ClientSize = new System.Drawing.Size(669, 455);
+            this.ClientSize = new System.Drawing.Size(1004, 772);
+            this.Controls.Add(this.grpSortingOptions);
             this.Controls.Add(this.grpOverlay);
             this.Controls.Add(this.grpStats);
             this.Controls.Add(this.btnSave);
@@ -573,10 +650,12 @@
             this.ForeColor = System.Drawing.Color.Black;
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "Settings";
             this.ShowInTaskbar = false;
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Settings";
             this.Load += new System.EventHandler(this.Settings_Load);
@@ -584,6 +663,10 @@
             this.grpOverlay.PerformLayout();
             this.grpStats.ResumeLayout(false);
             this.grpStats.PerformLayout();
+            this.grpSortingOptions.ResumeLayout(false);
+            this.grpSortingOptions.PerformLayout();
+            this.grpGameOptions.ResumeLayout(false);
+            this.grpGameOptions.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -625,7 +708,7 @@
         private System.Windows.Forms.CheckBox chkCycleOverlayPlayers;
         private System.Windows.Forms.CheckBox chkCycleOverlayStreak;
         private System.Windows.Forms.CheckBox chkChangeHoopsieLegends;
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label lblOrPing;
         private System.Windows.Forms.CheckBox chkOnlyShowPing;
         private System.Windows.Forms.Label lblOrFinal;
         private System.Windows.Forms.CheckBox chkOnlyShowFinalStreak;
@@ -633,5 +716,14 @@
         private System.Windows.Forms.CheckBox chkOnlyShowLongest;
         private System.Windows.Forms.Label lblOrGold;
         private System.Windows.Forms.CheckBox chkOnlyShowGold;
+        private System.Windows.Forms.GroupBox grpGameOptions;
+        private System.Windows.Forms.Button btnGameExeLocationBrowse;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TextBox txtGameExeLocation;
+        private System.IO.FileSystemWatcher fileSystemWatcher1;
+        private System.Windows.Forms.OpenFileDialog dlgGameExeBrowser;
+        private System.Windows.Forms.CheckBox chkAutoLaunchGameOnStart;
+        private System.Windows.Forms.GroupBox grpSortingOptions;
+        private System.Windows.Forms.CheckBox chkIgnoreLevelTypeWhenSorting;
     }
 }

--- a/Views/Settings.Designer.cs
+++ b/Views/Settings.Designer.cs
@@ -23,652 +23,720 @@
         /// the contents of this method with the code editor.
         /// </summary>
         private void InitializeComponent() {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Settings));
-            this.lblLogPath = new System.Windows.Forms.Label();
-            this.lblLogPathNote = new System.Windows.Forms.Label();
-            this.txtLogPath = new System.Windows.Forms.TextBox();
-            this.btnSave = new System.Windows.Forms.Button();
-            this.chkCycleOverlayQualify = new System.Windows.Forms.CheckBox();
-            this.chkCycleOverlayLongest = new System.Windows.Forms.CheckBox();
-            this.grpOverlay = new System.Windows.Forms.GroupBox();
-            this.lblOrPing = new System.Windows.Forms.Label();
-            this.chkOnlyShowPing = new System.Windows.Forms.CheckBox();
-            this.lblOrFinal = new System.Windows.Forms.Label();
-            this.chkOnlyShowFinalStreak = new System.Windows.Forms.CheckBox();
-            this.lblOrLongest = new System.Windows.Forms.Label();
-            this.chkOnlyShowLongest = new System.Windows.Forms.CheckBox();
-            this.lblOrGold = new System.Windows.Forms.Label();
-            this.chkOnlyShowGold = new System.Windows.Forms.CheckBox();
-            this.chkCycleOverlayStreak = new System.Windows.Forms.CheckBox();
-            this.chkCycleOverlayPlayers = new System.Windows.Forms.CheckBox();
-            this.chkHidePercentages = new System.Windows.Forms.CheckBox();
-            this.chkHideWinsInfo = new System.Windows.Forms.CheckBox();
-            this.cboOverlayColor = new System.Windows.Forms.ComboBox();
-            this.lblOverlayColor = new System.Windows.Forms.Label();
-            this.chkFlipped = new System.Windows.Forms.CheckBox();
-            this.chkShowTabs = new System.Windows.Forms.CheckBox();
-            this.chkHideTimeInfo = new System.Windows.Forms.CheckBox();
-            this.chkHideRoundInfo = new System.Windows.Forms.CheckBox();
-            this.cboFastestFilter = new System.Windows.Forms.ComboBox();
-            this.lblFastestFilter = new System.Windows.Forms.Label();
-            this.cboQualifyFilter = new System.Windows.Forms.ComboBox();
-            this.lblQualifyFilter = new System.Windows.Forms.Label();
-            this.cboWinsFilter = new System.Windows.Forms.ComboBox();
-            this.lblWinsFilter = new System.Windows.Forms.Label();
-            this.chkOverlayOnTop = new System.Windows.Forms.CheckBox();
-            this.chkUseNDI = new System.Windows.Forms.CheckBox();
-            this.lblCycleTimeSecondsTag = new System.Windows.Forms.Label();
-            this.lblCycleTimeSeconds = new System.Windows.Forms.Label();
-            this.txtCycleTimeSeconds = new System.Windows.Forms.TextBox();
-            this.grpStats = new System.Windows.Forms.GroupBox();
-            this.chkChangeHoopsieLegends = new System.Windows.Forms.CheckBox();
-            this.chkAutoUpdate = new System.Windows.Forms.CheckBox();
-            this.lblPreviousWinsNote = new System.Windows.Forms.Label();
-            this.lblPreviousWins = new System.Windows.Forms.Label();
-            this.txtPreviousWins = new System.Windows.Forms.TextBox();
-            this.grpSortingOptions = new System.Windows.Forms.GroupBox();
-            this.chkIgnoreLevelTypeWhenSorting = new System.Windows.Forms.CheckBox();
-            this.grpGameOptions = new System.Windows.Forms.GroupBox();
-            this.fileSystemWatcher1 = new System.IO.FileSystemWatcher();
-            this.txtGameExeLocation = new System.Windows.Forms.TextBox();
-            this.btnGameExeLocationBrowse = new System.Windows.Forms.Button();
-            this.dlgGameExeBrowser = new System.Windows.Forms.OpenFileDialog();
-            this.chkAutoLaunchGameOnStart = new System.Windows.Forms.CheckBox();
-            this.grpOverlay.SuspendLayout();
-            this.grpStats.SuspendLayout();
-            this.grpGameOptions.SuspendLayout();
-            this.grpSortingOptions.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.fileSystemWatcher1)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // lblLogPath
-            // 
-            this.lblLogPath.AutoSize = true;
-            this.lblLogPath.Location = new System.Drawing.Point(12, 23);
-            this.lblLogPath.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblLogPath.Name = "lblLogPath";
-            this.lblLogPath.Size = new System.Drawing.Size(73, 20);
-            this.lblLogPath.TabIndex = 0;
-            this.lblLogPath.Text = "Log Path";
-            // 
-            // lblLogPathNote
-            // 
-            this.lblLogPathNote.AutoSize = true;
-            this.lblLogPathNote.ForeColor = System.Drawing.Color.DimGray;
-            this.lblLogPathNote.Location = new System.Drawing.Point(92, 54);
-            this.lblLogPathNote.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblLogPathNote.Name = "lblLogPathNote";
-            this.lblLogPathNote.Size = new System.Drawing.Size(682, 20);
-            this.lblLogPathNote.TabIndex = 2;
-            this.lblLogPathNote.Text = "* You should not need to set this. Only use when the program is not reading the c" +
-          "orrect location.";
-            // 
-            // txtLogPath
-            // 
-            this.txtLogPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                  | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtLogPath.Location = new System.Drawing.Point(96, 18);
-            this.txtLogPath.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.txtLogPath.Name = "txtLogPath";
-            this.txtLogPath.Size = new System.Drawing.Size(888, 26);
-            this.txtLogPath.TabIndex = 1;
-            this.txtLogPath.Validating += new System.ComponentModel.CancelEventHandler(this.txtLogPath_Validating);
-            // 
-            // btnSave
-            // 
-            this.btnSave.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.btnSave.Location = new System.Drawing.Point(444, 714);
-            this.btnSave.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.btnSave.Name = "btnSave";
-            this.btnSave.Size = new System.Drawing.Size(112, 35);
-            this.btnSave.TabIndex = 5;
-            this.btnSave.Text = "Save";
-            this.btnSave.UseVisualStyleBackColor = true;
-            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
-            // 
-            // chkCycleOverlayQualify
-            // 
-            this.chkCycleOverlayQualify.AutoSize = true;
-            this.chkCycleOverlayQualify.Location = new System.Drawing.Point(24, 289);
-            this.chkCycleOverlayQualify.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkCycleOverlayQualify.Name = "chkCycleOverlayQualify";
-            this.chkCycleOverlayQualify.Size = new System.Drawing.Size(171, 24);
-            this.chkCycleOverlayQualify.TabIndex = 8;
-            this.chkCycleOverlayQualify.Text = "Cycle Qualify / Gold";
-            this.chkCycleOverlayQualify.UseVisualStyleBackColor = true;
-            this.chkCycleOverlayQualify.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
-            // 
-            // chkCycleOverlayLongest
-            // 
-            this.chkCycleOverlayLongest.AutoSize = true;
-            this.chkCycleOverlayLongest.Location = new System.Drawing.Point(24, 325);
-            this.chkCycleOverlayLongest.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkCycleOverlayLongest.Name = "chkCycleOverlayLongest";
-            this.chkCycleOverlayLongest.Size = new System.Drawing.Size(201, 24);
-            this.chkCycleOverlayLongest.TabIndex = 11;
-            this.chkCycleOverlayLongest.Text = "Cycle Fastest / Longest";
-            this.chkCycleOverlayLongest.UseVisualStyleBackColor = true;
-            this.chkCycleOverlayLongest.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
-            // 
-            // grpOverlay
-            // 
-            this.grpOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                  | System.Windows.Forms.AnchorStyles.Right)));
-            this.grpOverlay.Controls.Add(this.lblOrPing);
-            this.grpOverlay.Controls.Add(this.chkOnlyShowPing);
-            this.grpOverlay.Controls.Add(this.lblOrFinal);
-            this.grpOverlay.Controls.Add(this.chkOnlyShowFinalStreak);
-            this.grpOverlay.Controls.Add(this.lblOrLongest);
-            this.grpOverlay.Controls.Add(this.chkOnlyShowLongest);
-            this.grpOverlay.Controls.Add(this.lblOrGold);
-            this.grpOverlay.Controls.Add(this.chkOnlyShowGold);
-            this.grpOverlay.Controls.Add(this.chkCycleOverlayStreak);
-            this.grpOverlay.Controls.Add(this.chkCycleOverlayPlayers);
-            this.grpOverlay.Controls.Add(this.chkHidePercentages);
-            this.grpOverlay.Controls.Add(this.chkHideWinsInfo);
-            this.grpOverlay.Controls.Add(this.cboOverlayColor);
-            this.grpOverlay.Controls.Add(this.lblOverlayColor);
-            this.grpOverlay.Controls.Add(this.chkFlipped);
-            this.grpOverlay.Controls.Add(this.chkShowTabs);
-            this.grpOverlay.Controls.Add(this.chkHideTimeInfo);
-            this.grpOverlay.Controls.Add(this.chkHideRoundInfo);
-            this.grpOverlay.Controls.Add(this.cboFastestFilter);
-            this.grpOverlay.Controls.Add(this.lblFastestFilter);
-            this.grpOverlay.Controls.Add(this.cboQualifyFilter);
-            this.grpOverlay.Controls.Add(this.lblQualifyFilter);
-            this.grpOverlay.Controls.Add(this.cboWinsFilter);
-            this.grpOverlay.Controls.Add(this.lblWinsFilter);
-            this.grpOverlay.Controls.Add(this.chkOverlayOnTop);
-            this.grpOverlay.Controls.Add(this.chkUseNDI);
-            this.grpOverlay.Controls.Add(this.lblCycleTimeSecondsTag);
-            this.grpOverlay.Controls.Add(this.lblCycleTimeSeconds);
-            this.grpOverlay.Controls.Add(this.txtCycleTimeSeconds);
-            this.grpOverlay.Controls.Add(this.chkCycleOverlayQualify);
-            this.grpOverlay.Controls.Add(this.chkCycleOverlayLongest);
-            this.grpOverlay.Location = new System.Drawing.Point(18, 177);
-            this.grpOverlay.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.grpOverlay.Name = "grpOverlay";
-            this.grpOverlay.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.grpOverlay.Size = new System.Drawing.Size(968, 436);
-            this.grpOverlay.TabIndex = 4;
-            this.grpOverlay.TabStop = false;
-            this.grpOverlay.Text = "Overlay";
-            // 
-            // lblOrPing
-            // 
-            this.lblOrPing.AutoSize = true;
-            this.lblOrPing.ForeColor = System.Drawing.Color.DimGray;
-            this.lblOrPing.Location = new System.Drawing.Point(240, 397);
-            this.lblOrPing.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblOrPing.Name = "lblOrPing";
-            this.lblOrPing.Size = new System.Drawing.Size(23, 20);
-            this.lblOrPing.TabIndex = 18;
-            this.lblOrPing.Text = "or";
-            // 
-            // chkOnlyShowPing
-            // 
-            this.chkOnlyShowPing.AutoSize = true;
-            this.chkOnlyShowPing.Location = new System.Drawing.Point(290, 395);
-            this.chkOnlyShowPing.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkOnlyShowPing.Name = "chkOnlyShowPing";
-            this.chkOnlyShowPing.Size = new System.Drawing.Size(145, 24);
-            this.chkOnlyShowPing.TabIndex = 19;
-            this.chkOnlyShowPing.Text = "Only Show Ping";
-            this.chkOnlyShowPing.UseVisualStyleBackColor = true;
-            this.chkOnlyShowPing.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
-            // 
-            // lblOrFinal
-            // 
-            this.lblOrFinal.AutoSize = true;
-            this.lblOrFinal.ForeColor = System.Drawing.Color.DimGray;
-            this.lblOrFinal.Location = new System.Drawing.Point(240, 362);
-            this.lblOrFinal.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblOrFinal.Name = "lblOrFinal";
-            this.lblOrFinal.Size = new System.Drawing.Size(23, 20);
-            this.lblOrFinal.TabIndex = 15;
-            this.lblOrFinal.Text = "or";
-            // 
-            // chkOnlyShowFinalStreak
-            // 
-            this.chkOnlyShowFinalStreak.AutoSize = true;
-            this.chkOnlyShowFinalStreak.Location = new System.Drawing.Point(290, 360);
-            this.chkOnlyShowFinalStreak.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkOnlyShowFinalStreak.Name = "chkOnlyShowFinalStreak";
-            this.chkOnlyShowFinalStreak.Size = new System.Drawing.Size(199, 24);
-            this.chkOnlyShowFinalStreak.TabIndex = 16;
-            this.chkOnlyShowFinalStreak.Text = "Only Show Final Streak";
-            this.chkOnlyShowFinalStreak.UseVisualStyleBackColor = true;
-            this.chkOnlyShowFinalStreak.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
-            // 
-            // lblOrLongest
-            // 
-            this.lblOrLongest.AutoSize = true;
-            this.lblOrLongest.ForeColor = System.Drawing.Color.DimGray;
-            this.lblOrLongest.Location = new System.Drawing.Point(240, 326);
-            this.lblOrLongest.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblOrLongest.Name = "lblOrLongest";
-            this.lblOrLongest.Size = new System.Drawing.Size(23, 20);
-            this.lblOrLongest.TabIndex = 12;
-            this.lblOrLongest.Text = "or";
-            // 
-            // chkOnlyShowLongest
-            // 
-            this.chkOnlyShowLongest.AutoSize = true;
-            this.chkOnlyShowLongest.Location = new System.Drawing.Point(290, 325);
-            this.chkOnlyShowLongest.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkOnlyShowLongest.Name = "chkOnlyShowLongest";
-            this.chkOnlyShowLongest.Size = new System.Drawing.Size(172, 24);
-            this.chkOnlyShowLongest.TabIndex = 13;
-            this.chkOnlyShowLongest.Text = "Only Show Longest";
-            this.chkOnlyShowLongest.UseVisualStyleBackColor = true;
-            this.chkOnlyShowLongest.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
-            // 
-            // lblOrGold
-            // 
-            this.lblOrGold.AutoSize = true;
-            this.lblOrGold.ForeColor = System.Drawing.Color.DimGray;
-            this.lblOrGold.Location = new System.Drawing.Point(240, 291);
-            this.lblOrGold.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblOrGold.Name = "lblOrGold";
-            this.lblOrGold.Size = new System.Drawing.Size(23, 20);
-            this.lblOrGold.TabIndex = 9;
-            this.lblOrGold.Text = "or";
-            // 
-            // chkOnlyShowGold
-            // 
-            this.chkOnlyShowGold.AutoSize = true;
-            this.chkOnlyShowGold.Location = new System.Drawing.Point(290, 289);
-            this.chkOnlyShowGold.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkOnlyShowGold.Name = "chkOnlyShowGold";
-            this.chkOnlyShowGold.Size = new System.Drawing.Size(148, 24);
-            this.chkOnlyShowGold.TabIndex = 10;
-            this.chkOnlyShowGold.Text = "Only Show Gold";
-            this.chkOnlyShowGold.UseVisualStyleBackColor = true;
-            this.chkOnlyShowGold.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
-            // 
-            // chkCycleOverlayStreak
-            // 
-            this.chkCycleOverlayStreak.AutoSize = true;
-            this.chkCycleOverlayStreak.Location = new System.Drawing.Point(24, 360);
-            this.chkCycleOverlayStreak.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkCycleOverlayStreak.Name = "chkCycleOverlayStreak";
-            this.chkCycleOverlayStreak.Size = new System.Drawing.Size(201, 24);
-            this.chkCycleOverlayStreak.TabIndex = 14;
-            this.chkCycleOverlayStreak.Text = "Cycle Win / Final Streak";
-            this.chkCycleOverlayStreak.UseVisualStyleBackColor = true;
-            this.chkCycleOverlayStreak.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
-            // 
-            // chkCycleOverlayPlayers
-            // 
-            this.chkCycleOverlayPlayers.AutoSize = true;
-            this.chkCycleOverlayPlayers.Location = new System.Drawing.Point(24, 395);
-            this.chkCycleOverlayPlayers.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkCycleOverlayPlayers.Name = "chkCycleOverlayPlayers";
-            this.chkCycleOverlayPlayers.Size = new System.Drawing.Size(171, 24);
-            this.chkCycleOverlayPlayers.TabIndex = 17;
-            this.chkCycleOverlayPlayers.Text = "Cycle Players / Ping";
-            this.chkCycleOverlayPlayers.UseVisualStyleBackColor = true;
-            this.chkCycleOverlayPlayers.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
-            // 
-            // chkHidePercentages
-            // 
-            this.chkHidePercentages.AutoSize = true;
-            this.chkHidePercentages.Location = new System.Drawing.Point(24, 138);
-            this.chkHidePercentages.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkHidePercentages.Name = "chkHidePercentages";
-            this.chkHidePercentages.Size = new System.Drawing.Size(162, 24);
-            this.chkHidePercentages.TabIndex = 3;
-            this.chkHidePercentages.Text = "Hide Percentages";
-            this.chkHidePercentages.UseVisualStyleBackColor = true;
-            // 
-            // chkHideWinsInfo
-            // 
-            this.chkHideWinsInfo.AutoSize = true;
-            this.chkHideWinsInfo.Location = new System.Drawing.Point(24, 32);
-            this.chkHideWinsInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkHideWinsInfo.Name = "chkHideWinsInfo";
-            this.chkHideWinsInfo.Size = new System.Drawing.Size(137, 24);
-            this.chkHideWinsInfo.TabIndex = 0;
-            this.chkHideWinsInfo.Text = "Hide Wins info";
-            this.chkHideWinsInfo.UseVisualStyleBackColor = true;
-            // 
-            // cboOverlayColor
-            // 
-            this.cboOverlayColor.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cboOverlayColor.FormattingEnabled = true;
-            this.cboOverlayColor.Items.AddRange(new object[] {
+      System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Settings));
+      this.lblLogPath = new System.Windows.Forms.Label();
+      this.lblLogPathNote = new System.Windows.Forms.Label();
+      this.txtLogPath = new System.Windows.Forms.TextBox();
+      this.btnSave = new System.Windows.Forms.Button();
+      this.chkCycleOverlayQualify = new System.Windows.Forms.CheckBox();
+      this.chkCycleOverlayLongest = new System.Windows.Forms.CheckBox();
+      this.grpOverlay = new System.Windows.Forms.GroupBox();
+      this.lblOrPing = new System.Windows.Forms.Label();
+      this.chkOnlyShowPing = new System.Windows.Forms.CheckBox();
+      this.lblOrFinal = new System.Windows.Forms.Label();
+      this.chkOnlyShowFinalStreak = new System.Windows.Forms.CheckBox();
+      this.lblOrLongest = new System.Windows.Forms.Label();
+      this.chkOnlyShowLongest = new System.Windows.Forms.CheckBox();
+      this.lblOrGold = new System.Windows.Forms.Label();
+      this.chkOnlyShowGold = new System.Windows.Forms.CheckBox();
+      this.chkCycleOverlayStreak = new System.Windows.Forms.CheckBox();
+      this.chkCycleOverlayPlayers = new System.Windows.Forms.CheckBox();
+      this.chkHidePercentages = new System.Windows.Forms.CheckBox();
+      this.chkHideWinsInfo = new System.Windows.Forms.CheckBox();
+      this.cboOverlayColor = new System.Windows.Forms.ComboBox();
+      this.lblOverlayColor = new System.Windows.Forms.Label();
+      this.chkFlipped = new System.Windows.Forms.CheckBox();
+      this.chkShowTabs = new System.Windows.Forms.CheckBox();
+      this.chkHideTimeInfo = new System.Windows.Forms.CheckBox();
+      this.chkHideRoundInfo = new System.Windows.Forms.CheckBox();
+      this.cboFastestFilter = new System.Windows.Forms.ComboBox();
+      this.lblFastestFilter = new System.Windows.Forms.Label();
+      this.cboQualifyFilter = new System.Windows.Forms.ComboBox();
+      this.lblQualifyFilter = new System.Windows.Forms.Label();
+      this.cboWinsFilter = new System.Windows.Forms.ComboBox();
+      this.lblWinsFilter = new System.Windows.Forms.Label();
+      this.chkOverlayOnTop = new System.Windows.Forms.CheckBox();
+      this.chkUseNDI = new System.Windows.Forms.CheckBox();
+      this.lblCycleTimeSecondsTag = new System.Windows.Forms.Label();
+      this.lblCycleTimeSeconds = new System.Windows.Forms.Label();
+      this.txtCycleTimeSeconds = new System.Windows.Forms.TextBox();
+      this.grpStats = new System.Windows.Forms.GroupBox();
+      this.chkChangeHoopsieLegends = new System.Windows.Forms.CheckBox();
+      this.chkAutoUpdate = new System.Windows.Forms.CheckBox();
+      this.lblPreviousWinsNote = new System.Windows.Forms.Label();
+      this.lblPreviousWins = new System.Windows.Forms.Label();
+      this.txtPreviousWins = new System.Windows.Forms.TextBox();
+      this.grpSortingOptions = new System.Windows.Forms.GroupBox();
+      this.chkIgnoreLevelTypeWhenSorting = new System.Windows.Forms.CheckBox();
+      this.fileSystemWatcher1 = new System.IO.FileSystemWatcher();
+      this.txtGameExeLocation = new System.Windows.Forms.TextBox();
+      this.btnGameExeLocationBrowse = new System.Windows.Forms.Button();
+      this.dlgGameExeBrowser = new System.Windows.Forms.OpenFileDialog();
+      this.chkAutoLaunchGameOnStart = new System.Windows.Forms.CheckBox();
+      this.grpGameOptions = new System.Windows.Forms.GroupBox();
+      this.lblGameExeLocation = new System.Windows.Forms.Label();
+      this.btnCancel = new System.Windows.Forms.Button();
+      this.grpOverlay.SuspendLayout();
+      this.grpStats.SuspendLayout();
+      this.grpSortingOptions.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.fileSystemWatcher1)).BeginInit();
+      this.grpGameOptions.SuspendLayout();
+      this.SuspendLayout();
+      // 
+      // lblLogPath
+      // 
+      this.lblLogPath.AutoSize = true;
+      this.lblLogPath.Location = new System.Drawing.Point(12, 23);
+      this.lblLogPath.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblLogPath.Name = "lblLogPath";
+      this.lblLogPath.Size = new System.Drawing.Size(73, 20);
+      this.lblLogPath.TabIndex = 0;
+      this.lblLogPath.Text = "Log Path";
+      // 
+      // lblLogPathNote
+      // 
+      this.lblLogPathNote.AutoSize = true;
+      this.lblLogPathNote.ForeColor = System.Drawing.Color.DimGray;
+      this.lblLogPathNote.Location = new System.Drawing.Point(92, 54);
+      this.lblLogPathNote.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblLogPathNote.Name = "lblLogPathNote";
+      this.lblLogPathNote.Size = new System.Drawing.Size(682, 20);
+      this.lblLogPathNote.TabIndex = 2;
+      this.lblLogPathNote.Text = "* You should not need to set this. Only use when the program is not reading the c" +
+    "orrect location.";
+      // 
+      // txtLogPath
+      // 
+      this.txtLogPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+      this.txtLogPath.Location = new System.Drawing.Point(96, 18);
+      this.txtLogPath.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.txtLogPath.Name = "txtLogPath";
+      this.txtLogPath.Size = new System.Drawing.Size(888, 26);
+      this.txtLogPath.TabIndex = 1;
+      this.txtLogPath.Validating += new System.ComponentModel.CancelEventHandler(this.txtLogPath_Validating);
+      // 
+      // btnSave
+      // 
+      this.btnSave.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+      this.btnSave.Location = new System.Drawing.Point(750, 791);
+      this.btnSave.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.btnSave.Name = "btnSave";
+      this.btnSave.Size = new System.Drawing.Size(112, 35);
+      this.btnSave.TabIndex = 5;
+      this.btnSave.Text = "Save";
+      this.btnSave.UseVisualStyleBackColor = true;
+      this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+      // 
+      // chkCycleOverlayQualify
+      // 
+      this.chkCycleOverlayQualify.AutoSize = true;
+      this.chkCycleOverlayQualify.Location = new System.Drawing.Point(24, 289);
+      this.chkCycleOverlayQualify.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkCycleOverlayQualify.Name = "chkCycleOverlayQualify";
+      this.chkCycleOverlayQualify.Size = new System.Drawing.Size(171, 24);
+      this.chkCycleOverlayQualify.TabIndex = 8;
+      this.chkCycleOverlayQualify.Text = "Cycle Qualify / Gold";
+      this.chkCycleOverlayQualify.UseVisualStyleBackColor = true;
+      this.chkCycleOverlayQualify.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+      // 
+      // chkCycleOverlayLongest
+      // 
+      this.chkCycleOverlayLongest.AutoSize = true;
+      this.chkCycleOverlayLongest.Location = new System.Drawing.Point(24, 325);
+      this.chkCycleOverlayLongest.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkCycleOverlayLongest.Name = "chkCycleOverlayLongest";
+      this.chkCycleOverlayLongest.Size = new System.Drawing.Size(201, 24);
+      this.chkCycleOverlayLongest.TabIndex = 11;
+      this.chkCycleOverlayLongest.Text = "Cycle Fastest / Longest";
+      this.chkCycleOverlayLongest.UseVisualStyleBackColor = true;
+      this.chkCycleOverlayLongest.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+      // 
+      // grpOverlay
+      // 
+      this.grpOverlay.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+      this.grpOverlay.Controls.Add(this.lblOrPing);
+      this.grpOverlay.Controls.Add(this.chkOnlyShowPing);
+      this.grpOverlay.Controls.Add(this.lblOrFinal);
+      this.grpOverlay.Controls.Add(this.chkOnlyShowFinalStreak);
+      this.grpOverlay.Controls.Add(this.lblOrLongest);
+      this.grpOverlay.Controls.Add(this.chkOnlyShowLongest);
+      this.grpOverlay.Controls.Add(this.lblOrGold);
+      this.grpOverlay.Controls.Add(this.chkOnlyShowGold);
+      this.grpOverlay.Controls.Add(this.chkCycleOverlayStreak);
+      this.grpOverlay.Controls.Add(this.chkCycleOverlayPlayers);
+      this.grpOverlay.Controls.Add(this.chkHidePercentages);
+      this.grpOverlay.Controls.Add(this.chkHideWinsInfo);
+      this.grpOverlay.Controls.Add(this.cboOverlayColor);
+      this.grpOverlay.Controls.Add(this.lblOverlayColor);
+      this.grpOverlay.Controls.Add(this.chkFlipped);
+      this.grpOverlay.Controls.Add(this.chkShowTabs);
+      this.grpOverlay.Controls.Add(this.chkHideTimeInfo);
+      this.grpOverlay.Controls.Add(this.chkHideRoundInfo);
+      this.grpOverlay.Controls.Add(this.cboFastestFilter);
+      this.grpOverlay.Controls.Add(this.lblFastestFilter);
+      this.grpOverlay.Controls.Add(this.cboQualifyFilter);
+      this.grpOverlay.Controls.Add(this.lblQualifyFilter);
+      this.grpOverlay.Controls.Add(this.cboWinsFilter);
+      this.grpOverlay.Controls.Add(this.lblWinsFilter);
+      this.grpOverlay.Controls.Add(this.chkOverlayOnTop);
+      this.grpOverlay.Controls.Add(this.chkUseNDI);
+      this.grpOverlay.Controls.Add(this.lblCycleTimeSecondsTag);
+      this.grpOverlay.Controls.Add(this.lblCycleTimeSeconds);
+      this.grpOverlay.Controls.Add(this.txtCycleTimeSeconds);
+      this.grpOverlay.Controls.Add(this.chkCycleOverlayQualify);
+      this.grpOverlay.Controls.Add(this.chkCycleOverlayLongest);
+      this.grpOverlay.Location = new System.Drawing.Point(18, 177);
+      this.grpOverlay.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.grpOverlay.Name = "grpOverlay";
+      this.grpOverlay.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.grpOverlay.Size = new System.Drawing.Size(968, 436);
+      this.grpOverlay.TabIndex = 4;
+      this.grpOverlay.TabStop = false;
+      this.grpOverlay.Text = "Overlay";
+      // 
+      // lblOrPing
+      // 
+      this.lblOrPing.AutoSize = true;
+      this.lblOrPing.ForeColor = System.Drawing.Color.DimGray;
+      this.lblOrPing.Location = new System.Drawing.Point(240, 397);
+      this.lblOrPing.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblOrPing.Name = "lblOrPing";
+      this.lblOrPing.Size = new System.Drawing.Size(23, 20);
+      this.lblOrPing.TabIndex = 18;
+      this.lblOrPing.Text = "or";
+      // 
+      // chkOnlyShowPing
+      // 
+      this.chkOnlyShowPing.AutoSize = true;
+      this.chkOnlyShowPing.Location = new System.Drawing.Point(290, 395);
+      this.chkOnlyShowPing.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkOnlyShowPing.Name = "chkOnlyShowPing";
+      this.chkOnlyShowPing.Size = new System.Drawing.Size(145, 24);
+      this.chkOnlyShowPing.TabIndex = 19;
+      this.chkOnlyShowPing.Text = "Only Show Ping";
+      this.chkOnlyShowPing.UseVisualStyleBackColor = true;
+      this.chkOnlyShowPing.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+      // 
+      // lblOrFinal
+      // 
+      this.lblOrFinal.AutoSize = true;
+      this.lblOrFinal.ForeColor = System.Drawing.Color.DimGray;
+      this.lblOrFinal.Location = new System.Drawing.Point(240, 362);
+      this.lblOrFinal.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblOrFinal.Name = "lblOrFinal";
+      this.lblOrFinal.Size = new System.Drawing.Size(23, 20);
+      this.lblOrFinal.TabIndex = 15;
+      this.lblOrFinal.Text = "or";
+      // 
+      // chkOnlyShowFinalStreak
+      // 
+      this.chkOnlyShowFinalStreak.AutoSize = true;
+      this.chkOnlyShowFinalStreak.Location = new System.Drawing.Point(290, 360);
+      this.chkOnlyShowFinalStreak.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkOnlyShowFinalStreak.Name = "chkOnlyShowFinalStreak";
+      this.chkOnlyShowFinalStreak.Size = new System.Drawing.Size(199, 24);
+      this.chkOnlyShowFinalStreak.TabIndex = 16;
+      this.chkOnlyShowFinalStreak.Text = "Only Show Final Streak";
+      this.chkOnlyShowFinalStreak.UseVisualStyleBackColor = true;
+      this.chkOnlyShowFinalStreak.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+      // 
+      // lblOrLongest
+      // 
+      this.lblOrLongest.AutoSize = true;
+      this.lblOrLongest.ForeColor = System.Drawing.Color.DimGray;
+      this.lblOrLongest.Location = new System.Drawing.Point(240, 326);
+      this.lblOrLongest.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblOrLongest.Name = "lblOrLongest";
+      this.lblOrLongest.Size = new System.Drawing.Size(23, 20);
+      this.lblOrLongest.TabIndex = 12;
+      this.lblOrLongest.Text = "or";
+      // 
+      // chkOnlyShowLongest
+      // 
+      this.chkOnlyShowLongest.AutoSize = true;
+      this.chkOnlyShowLongest.Location = new System.Drawing.Point(290, 325);
+      this.chkOnlyShowLongest.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkOnlyShowLongest.Name = "chkOnlyShowLongest";
+      this.chkOnlyShowLongest.Size = new System.Drawing.Size(172, 24);
+      this.chkOnlyShowLongest.TabIndex = 13;
+      this.chkOnlyShowLongest.Text = "Only Show Longest";
+      this.chkOnlyShowLongest.UseVisualStyleBackColor = true;
+      this.chkOnlyShowLongest.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+      // 
+      // lblOrGold
+      // 
+      this.lblOrGold.AutoSize = true;
+      this.lblOrGold.ForeColor = System.Drawing.Color.DimGray;
+      this.lblOrGold.Location = new System.Drawing.Point(240, 291);
+      this.lblOrGold.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblOrGold.Name = "lblOrGold";
+      this.lblOrGold.Size = new System.Drawing.Size(23, 20);
+      this.lblOrGold.TabIndex = 9;
+      this.lblOrGold.Text = "or";
+      // 
+      // chkOnlyShowGold
+      // 
+      this.chkOnlyShowGold.AutoSize = true;
+      this.chkOnlyShowGold.Location = new System.Drawing.Point(290, 289);
+      this.chkOnlyShowGold.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkOnlyShowGold.Name = "chkOnlyShowGold";
+      this.chkOnlyShowGold.Size = new System.Drawing.Size(148, 24);
+      this.chkOnlyShowGold.TabIndex = 10;
+      this.chkOnlyShowGold.Text = "Only Show Gold";
+      this.chkOnlyShowGold.UseVisualStyleBackColor = true;
+      this.chkOnlyShowGold.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+      // 
+      // chkCycleOverlayStreak
+      // 
+      this.chkCycleOverlayStreak.AutoSize = true;
+      this.chkCycleOverlayStreak.Location = new System.Drawing.Point(24, 360);
+      this.chkCycleOverlayStreak.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkCycleOverlayStreak.Name = "chkCycleOverlayStreak";
+      this.chkCycleOverlayStreak.Size = new System.Drawing.Size(201, 24);
+      this.chkCycleOverlayStreak.TabIndex = 14;
+      this.chkCycleOverlayStreak.Text = "Cycle Win / Final Streak";
+      this.chkCycleOverlayStreak.UseVisualStyleBackColor = true;
+      this.chkCycleOverlayStreak.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+      // 
+      // chkCycleOverlayPlayers
+      // 
+      this.chkCycleOverlayPlayers.AutoSize = true;
+      this.chkCycleOverlayPlayers.Location = new System.Drawing.Point(24, 395);
+      this.chkCycleOverlayPlayers.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkCycleOverlayPlayers.Name = "chkCycleOverlayPlayers";
+      this.chkCycleOverlayPlayers.Size = new System.Drawing.Size(171, 24);
+      this.chkCycleOverlayPlayers.TabIndex = 17;
+      this.chkCycleOverlayPlayers.Text = "Cycle Players / Ping";
+      this.chkCycleOverlayPlayers.UseVisualStyleBackColor = true;
+      this.chkCycleOverlayPlayers.CheckedChanged += new System.EventHandler(this.chkCycleOnly_CheckedChanged);
+      // 
+      // chkHidePercentages
+      // 
+      this.chkHidePercentages.AutoSize = true;
+      this.chkHidePercentages.Location = new System.Drawing.Point(24, 138);
+      this.chkHidePercentages.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkHidePercentages.Name = "chkHidePercentages";
+      this.chkHidePercentages.Size = new System.Drawing.Size(162, 24);
+      this.chkHidePercentages.TabIndex = 3;
+      this.chkHidePercentages.Text = "Hide Percentages";
+      this.chkHidePercentages.UseVisualStyleBackColor = true;
+      // 
+      // chkHideWinsInfo
+      // 
+      this.chkHideWinsInfo.AutoSize = true;
+      this.chkHideWinsInfo.Location = new System.Drawing.Point(24, 32);
+      this.chkHideWinsInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkHideWinsInfo.Name = "chkHideWinsInfo";
+      this.chkHideWinsInfo.Size = new System.Drawing.Size(137, 24);
+      this.chkHideWinsInfo.TabIndex = 0;
+      this.chkHideWinsInfo.Text = "Hide Wins info";
+      this.chkHideWinsInfo.UseVisualStyleBackColor = true;
+      // 
+      // cboOverlayColor
+      // 
+      this.cboOverlayColor.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cboOverlayColor.FormattingEnabled = true;
+      this.cboOverlayColor.Items.AddRange(new object[] {
             "Transparent",
             "Magenta",
             "Red",
             "Green",
             "Blue",
             "Black"});
-            this.cboOverlayColor.Location = new System.Drawing.Point(670, 242);
-            this.cboOverlayColor.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.cboOverlayColor.Name = "cboOverlayColor";
-            this.cboOverlayColor.Size = new System.Drawing.Size(272, 28);
-            this.cboOverlayColor.TabIndex = 27;
-            // 
-            // lblOverlayColor
-            // 
-            this.lblOverlayColor.AutoSize = true;
-            this.lblOverlayColor.Location = new System.Drawing.Point(564, 246);
-            this.lblOverlayColor.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblOverlayColor.Name = "lblOverlayColor";
-            this.lblOverlayColor.Size = new System.Drawing.Size(95, 20);
-            this.lblOverlayColor.TabIndex = 26;
-            this.lblOverlayColor.Text = "Background";
-            // 
-            // chkFlipped
-            // 
-            this.chkFlipped.AutoSize = true;
-            this.chkFlipped.Location = new System.Drawing.Point(670, 289);
-            this.chkFlipped.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkFlipped.Name = "chkFlipped";
-            this.chkFlipped.Size = new System.Drawing.Size(195, 24);
-            this.chkFlipped.TabIndex = 28;
-            this.chkFlipped.Text = "Flip display horizontally";
-            this.chkFlipped.UseVisualStyleBackColor = true;
-            // 
-            // chkShowTabs
-            // 
-            this.chkShowTabs.AutoSize = true;
-            this.chkShowTabs.Location = new System.Drawing.Point(24, 174);
-            this.chkShowTabs.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkShowTabs.Name = "chkShowTabs";
-            this.chkShowTabs.Size = new System.Drawing.Size(217, 24);
-            this.chkShowTabs.TabIndex = 4;
-            this.chkShowTabs.Text = "Show Tab for current filter";
-            this.chkShowTabs.UseVisualStyleBackColor = true;
-            // 
-            // chkHideTimeInfo
-            // 
-            this.chkHideTimeInfo.AutoSize = true;
-            this.chkHideTimeInfo.Location = new System.Drawing.Point(24, 103);
-            this.chkHideTimeInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkHideTimeInfo.Name = "chkHideTimeInfo";
-            this.chkHideTimeInfo.Size = new System.Drawing.Size(136, 24);
-            this.chkHideTimeInfo.TabIndex = 2;
-            this.chkHideTimeInfo.Text = "Hide Time info";
-            this.chkHideTimeInfo.UseVisualStyleBackColor = true;
-            // 
-            // chkHideRoundInfo
-            // 
-            this.chkHideRoundInfo.AutoSize = true;
-            this.chkHideRoundInfo.Location = new System.Drawing.Point(24, 68);
-            this.chkHideRoundInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkHideRoundInfo.Name = "chkHideRoundInfo";
-            this.chkHideRoundInfo.Size = new System.Drawing.Size(150, 24);
-            this.chkHideRoundInfo.TabIndex = 1;
-            this.chkHideRoundInfo.Text = "Hide Round info";
-            this.chkHideRoundInfo.UseVisualStyleBackColor = true;
-            // 
-            // cboFastestFilter
-            // 
-            this.cboFastestFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cboFastestFilter.FormattingEnabled = true;
-            this.cboFastestFilter.Items.AddRange(new object[] {
+      this.cboOverlayColor.Location = new System.Drawing.Point(670, 242);
+      this.cboOverlayColor.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.cboOverlayColor.Name = "cboOverlayColor";
+      this.cboOverlayColor.Size = new System.Drawing.Size(272, 28);
+      this.cboOverlayColor.TabIndex = 27;
+      // 
+      // lblOverlayColor
+      // 
+      this.lblOverlayColor.AutoSize = true;
+      this.lblOverlayColor.Location = new System.Drawing.Point(564, 246);
+      this.lblOverlayColor.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblOverlayColor.Name = "lblOverlayColor";
+      this.lblOverlayColor.Size = new System.Drawing.Size(95, 20);
+      this.lblOverlayColor.TabIndex = 26;
+      this.lblOverlayColor.Text = "Background";
+      // 
+      // chkFlipped
+      // 
+      this.chkFlipped.AutoSize = true;
+      this.chkFlipped.Location = new System.Drawing.Point(670, 289);
+      this.chkFlipped.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkFlipped.Name = "chkFlipped";
+      this.chkFlipped.Size = new System.Drawing.Size(195, 24);
+      this.chkFlipped.TabIndex = 28;
+      this.chkFlipped.Text = "Flip display horizontally";
+      this.chkFlipped.UseVisualStyleBackColor = true;
+      // 
+      // chkShowTabs
+      // 
+      this.chkShowTabs.AutoSize = true;
+      this.chkShowTabs.Location = new System.Drawing.Point(24, 174);
+      this.chkShowTabs.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkShowTabs.Name = "chkShowTabs";
+      this.chkShowTabs.Size = new System.Drawing.Size(217, 24);
+      this.chkShowTabs.TabIndex = 4;
+      this.chkShowTabs.Text = "Show Tab for current filter";
+      this.chkShowTabs.UseVisualStyleBackColor = true;
+      // 
+      // chkHideTimeInfo
+      // 
+      this.chkHideTimeInfo.AutoSize = true;
+      this.chkHideTimeInfo.Location = new System.Drawing.Point(24, 103);
+      this.chkHideTimeInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkHideTimeInfo.Name = "chkHideTimeInfo";
+      this.chkHideTimeInfo.Size = new System.Drawing.Size(136, 24);
+      this.chkHideTimeInfo.TabIndex = 2;
+      this.chkHideTimeInfo.Text = "Hide Time info";
+      this.chkHideTimeInfo.UseVisualStyleBackColor = true;
+      // 
+      // chkHideRoundInfo
+      // 
+      this.chkHideRoundInfo.AutoSize = true;
+      this.chkHideRoundInfo.Location = new System.Drawing.Point(24, 68);
+      this.chkHideRoundInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkHideRoundInfo.Name = "chkHideRoundInfo";
+      this.chkHideRoundInfo.Size = new System.Drawing.Size(150, 24);
+      this.chkHideRoundInfo.TabIndex = 1;
+      this.chkHideRoundInfo.Text = "Hide Round info";
+      this.chkHideRoundInfo.UseVisualStyleBackColor = true;
+      // 
+      // cboFastestFilter
+      // 
+      this.cboFastestFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cboFastestFilter.FormattingEnabled = true;
+      this.cboFastestFilter.Items.AddRange(new object[] {
             "All Time Stats",
             "Stats and Party Filter",
             "Season Stats",
             "Week Stats",
             "Day Stats",
             "Session Stats"});
-            this.cboFastestFilter.Location = new System.Drawing.Point(670, 106);
-            this.cboFastestFilter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.cboFastestFilter.Name = "cboFastestFilter";
-            this.cboFastestFilter.Size = new System.Drawing.Size(272, 28);
-            this.cboFastestFilter.TabIndex = 25;
-            // 
-            // lblFastestFilter
-            // 
-            this.lblFastestFilter.AutoSize = true;
-            this.lblFastestFilter.Location = new System.Drawing.Point(489, 111);
-            this.lblFastestFilter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblFastestFilter.Name = "lblFastestFilter";
-            this.lblFastestFilter.Size = new System.Drawing.Size(172, 20);
-            this.lblFastestFilter.TabIndex = 24;
-            this.lblFastestFilter.Text = "Fastest / Longest Filter";
-            // 
-            // cboQualifyFilter
-            // 
-            this.cboQualifyFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cboQualifyFilter.FormattingEnabled = true;
-            this.cboQualifyFilter.Items.AddRange(new object[] {
+      this.cboFastestFilter.Location = new System.Drawing.Point(670, 106);
+      this.cboFastestFilter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.cboFastestFilter.Name = "cboFastestFilter";
+      this.cboFastestFilter.Size = new System.Drawing.Size(272, 28);
+      this.cboFastestFilter.TabIndex = 25;
+      // 
+      // lblFastestFilter
+      // 
+      this.lblFastestFilter.AutoSize = true;
+      this.lblFastestFilter.Location = new System.Drawing.Point(489, 111);
+      this.lblFastestFilter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblFastestFilter.Name = "lblFastestFilter";
+      this.lblFastestFilter.Size = new System.Drawing.Size(172, 20);
+      this.lblFastestFilter.TabIndex = 24;
+      this.lblFastestFilter.Text = "Fastest / Longest Filter";
+      // 
+      // cboQualifyFilter
+      // 
+      this.cboQualifyFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cboQualifyFilter.FormattingEnabled = true;
+      this.cboQualifyFilter.Items.AddRange(new object[] {
             "All Time Stats",
             "Stats and Party Filter",
             "Season Stats",
             "Week Stats",
             "Day Stats",
             "Session Stats"});
-            this.cboQualifyFilter.Location = new System.Drawing.Point(670, 68);
-            this.cboQualifyFilter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.cboQualifyFilter.Name = "cboQualifyFilter";
-            this.cboQualifyFilter.Size = new System.Drawing.Size(272, 28);
-            this.cboQualifyFilter.TabIndex = 23;
-            // 
-            // lblQualifyFilter
-            // 
-            this.lblQualifyFilter.AutoSize = true;
-            this.lblQualifyFilter.Location = new System.Drawing.Point(516, 72);
-            this.lblQualifyFilter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblQualifyFilter.Name = "lblQualifyFilter";
-            this.lblQualifyFilter.Size = new System.Drawing.Size(142, 20);
-            this.lblQualifyFilter.TabIndex = 22;
-            this.lblQualifyFilter.Text = "Qualify / Gold Filter";
-            // 
-            // cboWinsFilter
-            // 
-            this.cboWinsFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cboWinsFilter.FormattingEnabled = true;
-            this.cboWinsFilter.Items.AddRange(new object[] {
+      this.cboQualifyFilter.Location = new System.Drawing.Point(670, 68);
+      this.cboQualifyFilter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.cboQualifyFilter.Name = "cboQualifyFilter";
+      this.cboQualifyFilter.Size = new System.Drawing.Size(272, 28);
+      this.cboQualifyFilter.TabIndex = 23;
+      // 
+      // lblQualifyFilter
+      // 
+      this.lblQualifyFilter.AutoSize = true;
+      this.lblQualifyFilter.Location = new System.Drawing.Point(516, 72);
+      this.lblQualifyFilter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblQualifyFilter.Name = "lblQualifyFilter";
+      this.lblQualifyFilter.Size = new System.Drawing.Size(142, 20);
+      this.lblQualifyFilter.TabIndex = 22;
+      this.lblQualifyFilter.Text = "Qualify / Gold Filter";
+      // 
+      // cboWinsFilter
+      // 
+      this.cboWinsFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.cboWinsFilter.FormattingEnabled = true;
+      this.cboWinsFilter.Items.AddRange(new object[] {
             "All Time Stats",
             "Stats and Party Filter",
             "Season Stats",
             "Week Stats",
             "Day Stats",
             "Session Stats"});
-            this.cboWinsFilter.Location = new System.Drawing.Point(670, 29);
-            this.cboWinsFilter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.cboWinsFilter.Name = "cboWinsFilter";
-            this.cboWinsFilter.Size = new System.Drawing.Size(272, 28);
-            this.cboWinsFilter.TabIndex = 21;
-            // 
-            // lblWinsFilter
-            // 
-            this.lblWinsFilter.AutoSize = true;
-            this.lblWinsFilter.Location = new System.Drawing.Point(528, 34);
-            this.lblWinsFilter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblWinsFilter.Name = "lblWinsFilter";
-            this.lblWinsFilter.Size = new System.Drawing.Size(129, 20);
-            this.lblWinsFilter.TabIndex = 20;
-            this.lblWinsFilter.Text = "Wins / Final Filter";
-            // 
-            // chkOverlayOnTop
-            // 
-            this.chkOverlayOnTop.AutoSize = true;
-            this.chkOverlayOnTop.Location = new System.Drawing.Point(670, 325);
-            this.chkOverlayOnTop.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkOverlayOnTop.Name = "chkOverlayOnTop";
-            this.chkOverlayOnTop.Size = new System.Drawing.Size(174, 24);
-            this.chkOverlayOnTop.TabIndex = 29;
-            this.chkOverlayOnTop.Text = "Always show on top";
-            this.chkOverlayOnTop.UseVisualStyleBackColor = true;
-            // 
-            // chkUseNDI
-            // 
-            this.chkUseNDI.AutoSize = true;
-            this.chkUseNDI.Location = new System.Drawing.Point(670, 360);
-            this.chkUseNDI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkUseNDI.Name = "chkUseNDI";
-            this.chkUseNDI.Size = new System.Drawing.Size(231, 24);
-            this.chkUseNDI.TabIndex = 30;
-            this.chkUseNDI.Text = "Use NDI to transmit Overlay";
-            this.chkUseNDI.UseVisualStyleBackColor = true;
-            // 
-            // lblCycleTimeSecondsTag
-            // 
-            this.lblCycleTimeSecondsTag.AutoSize = true;
-            this.lblCycleTimeSecondsTag.Location = new System.Drawing.Point(188, 246);
-            this.lblCycleTimeSecondsTag.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblCycleTimeSecondsTag.Name = "lblCycleTimeSecondsTag";
-            this.lblCycleTimeSecondsTag.Size = new System.Drawing.Size(34, 20);
-            this.lblCycleTimeSecondsTag.TabIndex = 7;
-            this.lblCycleTimeSecondsTag.Text = "sec";
-            // 
-            // lblCycleTimeSeconds
-            // 
-            this.lblCycleTimeSeconds.AutoSize = true;
-            this.lblCycleTimeSeconds.Location = new System.Drawing.Point(28, 246);
-            this.lblCycleTimeSeconds.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblCycleTimeSeconds.Name = "lblCycleTimeSeconds";
-            this.lblCycleTimeSeconds.Size = new System.Drawing.Size(85, 20);
-            this.lblCycleTimeSeconds.TabIndex = 5;
-            this.lblCycleTimeSeconds.Text = "Cycle Time";
-            // 
-            // txtCycleTimeSeconds
-            // 
-            this.txtCycleTimeSeconds.Location = new System.Drawing.Point(126, 242);
-            this.txtCycleTimeSeconds.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.txtCycleTimeSeconds.MaxLength = 2;
-            this.txtCycleTimeSeconds.Name = "txtCycleTimeSeconds";
-            this.txtCycleTimeSeconds.Size = new System.Drawing.Size(50, 26);
-            this.txtCycleTimeSeconds.TabIndex = 6;
-            this.txtCycleTimeSeconds.Text = "5";
-            this.txtCycleTimeSeconds.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            this.txtCycleTimeSeconds.Validating += new System.ComponentModel.CancelEventHandler(this.txtCycleTimeSeconds_Validating);
-            // 
-            // grpStats
-            // 
-            this.grpStats.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                  | System.Windows.Forms.AnchorStyles.Right)));
-            this.grpStats.Controls.Add(this.chkChangeHoopsieLegends);
-            this.grpStats.Controls.Add(this.chkAutoUpdate);
-            this.grpStats.Controls.Add(this.lblPreviousWinsNote);
-            this.grpStats.Controls.Add(this.lblPreviousWins);
-            this.grpStats.Controls.Add(this.txtPreviousWins);
-            this.grpStats.Location = new System.Drawing.Point(18, 89);
-            this.grpStats.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.grpStats.Name = "grpStats";
-            this.grpStats.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.grpStats.Size = new System.Drawing.Size(968, 78);
-            this.grpStats.TabIndex = 3;
-            this.grpStats.TabStop = false;
-            this.grpStats.Text = "Stats";
-            // 
-            // chkChangeHoopsieLegends
-            // 
-            this.chkChangeHoopsieLegends.AutoSize = true;
-            this.chkChangeHoopsieLegends.Location = new System.Drawing.Point(585, 32);
-            this.chkChangeHoopsieLegends.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkChangeHoopsieLegends.Name = "chkChangeHoopsieLegends";
-            this.chkChangeHoopsieLegends.Size = new System.Drawing.Size(362, 24);
-            this.chkChangeHoopsieLegends.TabIndex = 4;
-            this.chkChangeHoopsieLegends.Text = "Rename Hoopsie Legends to Hoopsie Heroes";
-            this.chkChangeHoopsieLegends.UseVisualStyleBackColor = true;
-            // 
-            // chkAutoUpdate
-            // 
-            this.chkAutoUpdate.AutoSize = true;
-            this.chkAutoUpdate.Location = new System.Drawing.Point(381, 32);
-            this.chkAutoUpdate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.chkAutoUpdate.Name = "chkAutoUpdate";
-            this.chkAutoUpdate.Size = new System.Drawing.Size(190, 24);
-            this.chkAutoUpdate.TabIndex = 3;
-            this.chkAutoUpdate.Text = "Auto Update Program";
-            this.chkAutoUpdate.UseVisualStyleBackColor = true;
-            // 
-            // lblPreviousWinsNote
-            // 
-            this.lblPreviousWinsNote.AutoSize = true;
-            this.lblPreviousWinsNote.ForeColor = System.Drawing.Color.DimGray;
-            this.lblPreviousWinsNote.Location = new System.Drawing.Point(200, 34);
-            this.lblPreviousWinsNote.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblPreviousWinsNote.Name = "lblPreviousWinsNote";
-            this.lblPreviousWinsNote.Size = new System.Drawing.Size(162, 20);
-            this.lblPreviousWinsNote.TabIndex = 2;
-            this.lblPreviousWinsNote.Text = "(Before using tracker)";
-            // 
-            // lblPreviousWins
-            // 
-            this.lblPreviousWins.AutoSize = true;
-            this.lblPreviousWins.Location = new System.Drawing.Point(16, 34);
-            this.lblPreviousWins.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblPreviousWins.Name = "lblPreviousWins";
-            this.lblPreviousWins.Size = new System.Drawing.Size(108, 20);
-            this.lblPreviousWins.TabIndex = 0;
-            this.lblPreviousWins.Text = "Previous Wins";
-            // 
-            // txtPreviousWins
-            // 
-            this.txtPreviousWins.Location = new System.Drawing.Point(138, 29);
-            this.txtPreviousWins.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.txtPreviousWins.MaxLength = 4;
-            this.txtPreviousWins.Name = "txtPreviousWins";
-            this.txtPreviousWins.Size = new System.Drawing.Size(50, 26);
-            this.txtPreviousWins.TabIndex = 1;
-            this.txtPreviousWins.Text = "0";
-            this.txtPreviousWins.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            this.txtPreviousWins.Validating += new System.ComponentModel.CancelEventHandler(this.txtPreviousWins_Validating);
-            // 
-            // grpSortingOptions
-            // 
-            this.grpSortingOptions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                  | System.Windows.Forms.AnchorStyles.Right)));
-            this.grpSortingOptions.Controls.Add(this.chkIgnoreLevelTypeWhenSorting);
-            this.grpSortingOptions.Location = new System.Drawing.Point(18, 625);
-            this.grpSortingOptions.Name = "grpSortingOptions";
-            this.grpSortingOptions.Size = new System.Drawing.Size(968, 66);
-            this.grpSortingOptions.TabIndex = 6;
-            this.grpSortingOptions.TabStop = false;
-            this.grpSortingOptions.Text = "Sorting Options";
-            // 
-            // chkIgnoreLevelTypeWhenSorting
-            // 
-            this.chkIgnoreLevelTypeWhenSorting.AutoSize = true;
-            this.chkIgnoreLevelTypeWhenSorting.Location = new System.Drawing.Point(24, 26);
-            this.chkIgnoreLevelTypeWhenSorting.Name = "chkIgnoreLevelTypeWhenSorting";
-            this.chkIgnoreLevelTypeWhenSorting.Size = new System.Drawing.Size(254, 24);
-            this.chkIgnoreLevelTypeWhenSorting.TabIndex = 0;
-            this.chkIgnoreLevelTypeWhenSorting.Text = "Ignore Level Type when sorting";
-            this.chkIgnoreLevelTypeWhenSorting.UseVisualStyleBackColor = true;
-            // 
-            // Settings
-            // 
-            this.AcceptButton = this.btnSave;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(242)))), ((int)(((byte)(251)))));
-            this.ClientSize = new System.Drawing.Size(1004, 772);
-            this.Controls.Add(this.grpSortingOptions);
-            this.Controls.Add(this.grpOverlay);
-            this.Controls.Add(this.grpStats);
-            this.Controls.Add(this.btnSave);
-            this.Controls.Add(this.txtLogPath);
-            this.Controls.Add(this.lblLogPathNote);
-            this.Controls.Add(this.lblLogPath);
-            this.ForeColor = System.Drawing.Color.Black;
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "Settings";
-            this.ShowInTaskbar = false;
-            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Settings";
-            this.Load += new System.EventHandler(this.Settings_Load);
-            this.grpOverlay.ResumeLayout(false);
-            this.grpOverlay.PerformLayout();
-            this.grpStats.ResumeLayout(false);
-            this.grpStats.PerformLayout();
-            this.grpSortingOptions.ResumeLayout(false);
-            this.grpSortingOptions.PerformLayout();
-            this.grpGameOptions.ResumeLayout(false);
-            this.grpGameOptions.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+      this.cboWinsFilter.Location = new System.Drawing.Point(670, 29);
+      this.cboWinsFilter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.cboWinsFilter.Name = "cboWinsFilter";
+      this.cboWinsFilter.Size = new System.Drawing.Size(272, 28);
+      this.cboWinsFilter.TabIndex = 21;
+      // 
+      // lblWinsFilter
+      // 
+      this.lblWinsFilter.AutoSize = true;
+      this.lblWinsFilter.Location = new System.Drawing.Point(528, 34);
+      this.lblWinsFilter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblWinsFilter.Name = "lblWinsFilter";
+      this.lblWinsFilter.Size = new System.Drawing.Size(129, 20);
+      this.lblWinsFilter.TabIndex = 20;
+      this.lblWinsFilter.Text = "Wins / Final Filter";
+      // 
+      // chkOverlayOnTop
+      // 
+      this.chkOverlayOnTop.AutoSize = true;
+      this.chkOverlayOnTop.Location = new System.Drawing.Point(670, 325);
+      this.chkOverlayOnTop.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkOverlayOnTop.Name = "chkOverlayOnTop";
+      this.chkOverlayOnTop.Size = new System.Drawing.Size(174, 24);
+      this.chkOverlayOnTop.TabIndex = 29;
+      this.chkOverlayOnTop.Text = "Always show on top";
+      this.chkOverlayOnTop.UseVisualStyleBackColor = true;
+      // 
+      // chkUseNDI
+      // 
+      this.chkUseNDI.AutoSize = true;
+      this.chkUseNDI.Location = new System.Drawing.Point(670, 360);
+      this.chkUseNDI.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkUseNDI.Name = "chkUseNDI";
+      this.chkUseNDI.Size = new System.Drawing.Size(231, 24);
+      this.chkUseNDI.TabIndex = 30;
+      this.chkUseNDI.Text = "Use NDI to transmit Overlay";
+      this.chkUseNDI.UseVisualStyleBackColor = true;
+      // 
+      // lblCycleTimeSecondsTag
+      // 
+      this.lblCycleTimeSecondsTag.AutoSize = true;
+      this.lblCycleTimeSecondsTag.Location = new System.Drawing.Point(188, 246);
+      this.lblCycleTimeSecondsTag.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblCycleTimeSecondsTag.Name = "lblCycleTimeSecondsTag";
+      this.lblCycleTimeSecondsTag.Size = new System.Drawing.Size(34, 20);
+      this.lblCycleTimeSecondsTag.TabIndex = 7;
+      this.lblCycleTimeSecondsTag.Text = "sec";
+      // 
+      // lblCycleTimeSeconds
+      // 
+      this.lblCycleTimeSeconds.AutoSize = true;
+      this.lblCycleTimeSeconds.Location = new System.Drawing.Point(28, 246);
+      this.lblCycleTimeSeconds.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblCycleTimeSeconds.Name = "lblCycleTimeSeconds";
+      this.lblCycleTimeSeconds.Size = new System.Drawing.Size(85, 20);
+      this.lblCycleTimeSeconds.TabIndex = 5;
+      this.lblCycleTimeSeconds.Text = "Cycle Time";
+      // 
+      // txtCycleTimeSeconds
+      // 
+      this.txtCycleTimeSeconds.Location = new System.Drawing.Point(126, 242);
+      this.txtCycleTimeSeconds.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.txtCycleTimeSeconds.MaxLength = 2;
+      this.txtCycleTimeSeconds.Name = "txtCycleTimeSeconds";
+      this.txtCycleTimeSeconds.Size = new System.Drawing.Size(50, 26);
+      this.txtCycleTimeSeconds.TabIndex = 6;
+      this.txtCycleTimeSeconds.Text = "5";
+      this.txtCycleTimeSeconds.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+      this.txtCycleTimeSeconds.Validating += new System.ComponentModel.CancelEventHandler(this.txtCycleTimeSeconds_Validating);
+      // 
+      // grpStats
+      // 
+      this.grpStats.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+      this.grpStats.Controls.Add(this.chkChangeHoopsieLegends);
+      this.grpStats.Controls.Add(this.chkAutoUpdate);
+      this.grpStats.Controls.Add(this.lblPreviousWinsNote);
+      this.grpStats.Controls.Add(this.lblPreviousWins);
+      this.grpStats.Controls.Add(this.txtPreviousWins);
+      this.grpStats.Location = new System.Drawing.Point(18, 89);
+      this.grpStats.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.grpStats.Name = "grpStats";
+      this.grpStats.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.grpStats.Size = new System.Drawing.Size(968, 78);
+      this.grpStats.TabIndex = 3;
+      this.grpStats.TabStop = false;
+      this.grpStats.Text = "Stats";
+      // 
+      // chkChangeHoopsieLegends
+      // 
+      this.chkChangeHoopsieLegends.AutoSize = true;
+      this.chkChangeHoopsieLegends.Location = new System.Drawing.Point(585, 32);
+      this.chkChangeHoopsieLegends.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkChangeHoopsieLegends.Name = "chkChangeHoopsieLegends";
+      this.chkChangeHoopsieLegends.Size = new System.Drawing.Size(362, 24);
+      this.chkChangeHoopsieLegends.TabIndex = 4;
+      this.chkChangeHoopsieLegends.Text = "Rename Hoopsie Legends to Hoopsie Heroes";
+      this.chkChangeHoopsieLegends.UseVisualStyleBackColor = true;
+      // 
+      // chkAutoUpdate
+      // 
+      this.chkAutoUpdate.AutoSize = true;
+      this.chkAutoUpdate.Location = new System.Drawing.Point(381, 32);
+      this.chkAutoUpdate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkAutoUpdate.Name = "chkAutoUpdate";
+      this.chkAutoUpdate.Size = new System.Drawing.Size(190, 24);
+      this.chkAutoUpdate.TabIndex = 3;
+      this.chkAutoUpdate.Text = "Auto Update Program";
+      this.chkAutoUpdate.UseVisualStyleBackColor = true;
+      // 
+      // lblPreviousWinsNote
+      // 
+      this.lblPreviousWinsNote.AutoSize = true;
+      this.lblPreviousWinsNote.ForeColor = System.Drawing.Color.DimGray;
+      this.lblPreviousWinsNote.Location = new System.Drawing.Point(200, 34);
+      this.lblPreviousWinsNote.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblPreviousWinsNote.Name = "lblPreviousWinsNote";
+      this.lblPreviousWinsNote.Size = new System.Drawing.Size(162, 20);
+      this.lblPreviousWinsNote.TabIndex = 2;
+      this.lblPreviousWinsNote.Text = "(Before using tracker)";
+      // 
+      // lblPreviousWins
+      // 
+      this.lblPreviousWins.AutoSize = true;
+      this.lblPreviousWins.Location = new System.Drawing.Point(16, 34);
+      this.lblPreviousWins.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblPreviousWins.Name = "lblPreviousWins";
+      this.lblPreviousWins.Size = new System.Drawing.Size(108, 20);
+      this.lblPreviousWins.TabIndex = 0;
+      this.lblPreviousWins.Text = "Previous Wins";
+      // 
+      // txtPreviousWins
+      // 
+      this.txtPreviousWins.Location = new System.Drawing.Point(138, 29);
+      this.txtPreviousWins.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.txtPreviousWins.MaxLength = 4;
+      this.txtPreviousWins.Name = "txtPreviousWins";
+      this.txtPreviousWins.Size = new System.Drawing.Size(50, 26);
+      this.txtPreviousWins.TabIndex = 1;
+      this.txtPreviousWins.Text = "0";
+      this.txtPreviousWins.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+      this.txtPreviousWins.Validating += new System.ComponentModel.CancelEventHandler(this.txtPreviousWins_Validating);
+      // 
+      // grpSortingOptions
+      // 
+      this.grpSortingOptions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+      this.grpSortingOptions.Controls.Add(this.chkIgnoreLevelTypeWhenSorting);
+      this.grpSortingOptions.Location = new System.Drawing.Point(18, 621);
+      this.grpSortingOptions.Name = "grpSortingOptions";
+      this.grpSortingOptions.Size = new System.Drawing.Size(968, 62);
+      this.grpSortingOptions.TabIndex = 6;
+      this.grpSortingOptions.TabStop = false;
+      this.grpSortingOptions.Text = "Sorting Options";
+      // 
+      // chkIgnoreLevelTypeWhenSorting
+      // 
+      this.chkIgnoreLevelTypeWhenSorting.AutoSize = true;
+      this.chkIgnoreLevelTypeWhenSorting.Location = new System.Drawing.Point(24, 26);
+      this.chkIgnoreLevelTypeWhenSorting.Name = "chkIgnoreLevelTypeWhenSorting";
+      this.chkIgnoreLevelTypeWhenSorting.Size = new System.Drawing.Size(254, 24);
+      this.chkIgnoreLevelTypeWhenSorting.TabIndex = 0;
+      this.chkIgnoreLevelTypeWhenSorting.Text = "Ignore Level Type when sorting";
+      this.chkIgnoreLevelTypeWhenSorting.UseVisualStyleBackColor = true;
+      // 
+      // fileSystemWatcher1
+      // 
+      this.fileSystemWatcher1.EnableRaisingEvents = true;
+      this.fileSystemWatcher1.SynchronizingObject = this;
+      // 
+      // txtGameExeLocation
+      // 
+      this.txtGameExeLocation.Enabled = false;
+      this.txtGameExeLocation.Location = new System.Drawing.Point(210, 22);
+      this.txtGameExeLocation.Name = "txtGameExeLocation";
+      this.txtGameExeLocation.Size = new System.Drawing.Size(669, 26);
+      this.txtGameExeLocation.TabIndex = 0;
+      // 
+      // btnGameExeLocationBrowse
+      // 
+      this.btnGameExeLocationBrowse.Location = new System.Drawing.Point(885, 20);
+      this.btnGameExeLocationBrowse.Name = "btnGameExeLocationBrowse";
+      this.btnGameExeLocationBrowse.Size = new System.Drawing.Size(75, 30);
+      this.btnGameExeLocationBrowse.TabIndex = 0;
+      this.btnGameExeLocationBrowse.Text = "Browse";
+      // 
+      // chkAutoLaunchGameOnStart
+      // 
+      this.chkAutoLaunchGameOnStart.Location = new System.Drawing.Point(20, 60);
+      this.chkAutoLaunchGameOnStart.Name = "chkAutoLaunchGameOnStart";
+      this.chkAutoLaunchGameOnStart.Size = new System.Drawing.Size(306, 24);
+      this.chkAutoLaunchGameOnStart.TabIndex = 0;
+      this.chkAutoLaunchGameOnStart.Text = "Auto-launch Fall Guys on tracker start";
+      // 
+      // grpGameOptions
+      // 
+      this.grpGameOptions.Controls.Add(this.lblGameExeLocation);
+      this.grpGameOptions.Controls.Add(this.txtGameExeLocation);
+      this.grpGameOptions.Controls.Add(this.btnGameExeLocationBrowse);
+      this.grpGameOptions.Controls.Add(this.chkAutoLaunchGameOnStart);
+      this.grpGameOptions.Location = new System.Drawing.Point(18, 689);
+      this.grpGameOptions.Name = "grpGameOptions";
+      this.grpGameOptions.Size = new System.Drawing.Size(966, 93);
+      this.grpGameOptions.TabIndex = 0;
+      this.grpGameOptions.TabStop = false;
+      this.grpGameOptions.Text = "Game Options";
+      // 
+      // lblGameExeLocation
+      // 
+      this.lblGameExeLocation.AutoSize = true;
+      this.lblGameExeLocation.Location = new System.Drawing.Point(16, 25);
+      this.lblGameExeLocation.Name = "lblGameExeLocation";
+      this.lblGameExeLocation.Size = new System.Drawing.Size(188, 20);
+      this.lblGameExeLocation.TabIndex = 1;
+      this.lblGameExeLocation.Text = "Fall Guys Game Location";
+      // 
+      // btnCancel
+      // 
+      this.btnCancel.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+      this.btnCancel.Location = new System.Drawing.Point(872, 791);
+      this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.btnCancel.Name = "btnCancel";
+      this.btnCancel.Size = new System.Drawing.Size(112, 35);
+      this.btnCancel.TabIndex = 7;
+      this.btnCancel.Text = "Cancel";
+      this.btnCancel.UseVisualStyleBackColor = true;
+      this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+      // 
+      // Settings
+      // 
+      this.AcceptButton = this.btnSave;
+      this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(242)))), ((int)(((byte)(251)))));
+      this.ClientSize = new System.Drawing.Size(1004, 840);
+      this.Controls.Add(this.btnCancel);
+      this.Controls.Add(this.grpGameOptions);
+      this.Controls.Add(this.grpSortingOptions);
+      this.Controls.Add(this.grpOverlay);
+      this.Controls.Add(this.grpStats);
+      this.Controls.Add(this.btnSave);
+      this.Controls.Add(this.txtLogPath);
+      this.Controls.Add(this.lblLogPathNote);
+      this.Controls.Add(this.lblLogPath);
+      this.ForeColor = System.Drawing.Color.Black;
+      this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+      this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+      this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.MaximizeBox = false;
+      this.MinimizeBox = false;
+      this.Name = "Settings";
+      this.ShowInTaskbar = false;
+      this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+      this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+      this.Text = "Settings";
+      this.Load += new System.EventHandler(this.Settings_Load);
+      this.grpOverlay.ResumeLayout(false);
+      this.grpOverlay.PerformLayout();
+      this.grpStats.ResumeLayout(false);
+      this.grpStats.PerformLayout();
+      this.grpSortingOptions.ResumeLayout(false);
+      this.grpSortingOptions.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.fileSystemWatcher1)).EndInit();
+      this.grpGameOptions.ResumeLayout(false);
+      this.grpGameOptions.PerformLayout();
+      this.ResumeLayout(false);
+      this.PerformLayout();
 
         }
 
@@ -716,7 +784,6 @@
         private System.Windows.Forms.CheckBox chkOnlyShowLongest;
         private System.Windows.Forms.Label lblOrGold;
         private System.Windows.Forms.CheckBox chkOnlyShowGold;
-        private System.Windows.Forms.GroupBox grpGameOptions;
         private System.Windows.Forms.Button btnGameExeLocationBrowse;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.TextBox txtGameExeLocation;
@@ -725,5 +792,8 @@
         private System.Windows.Forms.CheckBox chkAutoLaunchGameOnStart;
         private System.Windows.Forms.GroupBox grpSortingOptions;
         private System.Windows.Forms.CheckBox chkIgnoreLevelTypeWhenSorting;
+        private System.Windows.Forms.GroupBox grpGameOptions;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.Label lblGameExeLocation;
     }
 }

--- a/Views/Settings.cs
+++ b/Views/Settings.cs
@@ -62,6 +62,11 @@ namespace FallGuysStats {
                 case 4: cboFastestFilter.SelectedItem = "Day Stats"; break;
                 case 5: cboFastestFilter.SelectedItem = "Session Stats"; break;
             }
+
+            txtGameExeLocation.Text = CurrentSettings.GameExeLocation;
+            chkAutoLaunchGameOnStart.Checked = CurrentSettings.AutoLaunchGameOnStartup;
+
+            chkIgnoreLevelTypeWhenSorting.Checked = this.CurrentSettings.IgnoreLevelTypeWhenSorting;
         }
 
         private void btnSave_Click(object sender, EventArgs e) {
@@ -164,8 +169,13 @@ namespace FallGuysStats {
                 }
             }
 
-            this.DialogResult = DialogResult.OK;
-            this.Close();
+            this.CurrentSettings.IgnoreLevelTypeWhenSorting = chkIgnoreLevelTypeWhenSorting.Checked;
+
+            CurrentSettings.GameExeLocation = txtGameExeLocation.Text;
+            CurrentSettings.AutoLaunchGameOnStartup = chkAutoLaunchGameOnStart.Checked;
+
+            DialogResult = DialogResult.OK;
+            Close();
         }
         private void txtCycleTimeSeconds_Validating(object sender, System.ComponentModel.CancelEventArgs e) {
             if (!string.IsNullOrEmpty(txtCycleTimeSeconds.Text) && !int.TryParse(txtCycleTimeSeconds.Text, out _)) {
@@ -201,6 +211,31 @@ namespace FallGuysStats {
                 chkCycleOverlayPlayers.Checked = false;
             } else if (sender == chkCycleOverlayPlayers && chkCycleOverlayPlayers.Checked && chkOnlyShowPing.Checked) {
                 chkOnlyShowPing.Checked = false;
+            }
+        }
+
+        private void btnGameExeLocationBrowse_Click(object sender, EventArgs e) {
+            try {
+            FileInfo currentExeLocation = new FileInfo(this.txtGameExeLocation.Text);
+            if(currentExeLocation.Directory.Exists) {
+                dlgGameExeBrowser.InitialDirectory = currentExeLocation.Directory.FullName;
+            }
+
+            dlgGameExeBrowser.Filter = "Exe files (*.exe)|*.exe";
+            dlgGameExeBrowser.FileName = "FallGuys_client.exe";
+
+            DialogResult result = dlgGameExeBrowser.ShowDialog();
+            if (result.Equals(DialogResult.OK)) {
+                if (txtGameExeLocation.Text.Contains("FallGuys_client.exe")) {
+                    txtGameExeLocation.Text = dlgGameExeBrowser.FileName;
+                } else {
+                    MessageBox.Show("Please select \"FallGuys_client.exe\" in the install folder.",
+                        "Wrong File Selected", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+
+                }
+            } catch (Exception ex) {
+                ControlErrors.HandleException(this, ex, false);
             }
         }
     }

--- a/Views/Settings.cs
+++ b/Views/Settings.cs
@@ -238,5 +238,9 @@ namespace FallGuysStats {
                 ControlErrors.HandleException(this, ex, false);
             }
         }
+
+        private void btnCancel_Click(object sender, EventArgs e) {
+            this.Close();
+        }
     }
 }

--- a/Views/Settings.resx
+++ b/Views/Settings.resx
@@ -117,20 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="btnGameExeLocationBrowse.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAADGSURBVDhPYwCBb9++KQCxAx4sAFaIDQAl5wPxfwJ4PlQ5
-        Jvj87vn/e7ua/t/ZVoUV39/XBTMkAIhhLlKAage7AKwQRGPDIAPe3DuBTQ7iKhAHnwEgzcguAmGQi0Fy
-        RBmADcPUU2wAEDtQasB/FAOw+RcXhocDsgGPj83EUIgLPzu3EqRnPtwAUHpAV4QPf3x1H2QAIgyeX9qA
-        oQgXfnhoIkjzfXgsgPyDLzWiY2jCKoAZ0AAyhAwMyWD///+nCGMVJB7/ZwAAcD0dv904tJwAAAAASUVO
-        RK5CYII=
-</value>
-  </data>
   <metadata name="fileSystemWatcher1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAEAQEAAAAEAIAAoQgAAFgAAACgAAABAAAAAgAAAAAEAIAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAA

--- a/Views/Settings.resx
+++ b/Views/Settings.resx
@@ -118,6 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="btnGameExeLocationBrowse.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAADGSURBVDhPYwCBb9++KQCxAx4sAFaIDQAl5wPxfwJ4PlQ5
+        Jvj87vn/e7ua/t/ZVoUV39/XBTMkAIhhLlKAage7AKwQRGPDIAPe3DuBTQ7iKhAHnwEgzcguAmGQi0Fy
+        RBmADcPUU2wAEDtQasB/FAOw+RcXhocDsgGPj83EUIgLPzu3EqRnPtwAUHpAV4QPf3x1H2QAIgyeX9qA
+        oQgXfnhoIkjzfXgsgPyDLzWiY2jCKoAZ0AAyhAwMyWD///+nCGMVJB7/ZwAAcD0dv904tJwAAAAASUVO
+        RK5CYII=
+</value>
+  </data>
+  <metadata name="fileSystemWatcher1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAEAQEAAAAEAIAAoQgAAFgAAACgAAABAAAAAgAAAAAEAIAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAA
@@ -405,4 +418,7 @@
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 </value>
   </data>
+  <metadata name="dlgGameExeBrowser.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>240, 17</value>
+  </metadata>
 </root>

--- a/Views/Stats.Designer.cs
+++ b/Views/Stats.Designer.cs
@@ -24,9 +24,9 @@
         /// </summary>
         private void InitializeComponent() {
       this.components = new System.ComponentModel.Container();
-      System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-      System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
       System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Stats));
+      System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+      System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
       this.menu = new System.Windows.Forms.MenuStrip();
       this.menuSettings = new System.Windows.Forms.ToolStripMenuItem();
       this.menuFilters = new System.Windows.Forms.ToolStripMenuItem();
@@ -47,20 +47,20 @@
       this.menuUpdate = new System.Windows.Forms.ToolStripMenuItem();
       this.menuHelp = new System.Windows.Forms.ToolStripMenuItem();
       this.mainToolStrip = new System.Windows.Forms.ToolStrip();
+      this.tsbtnLaunchGame = new System.Windows.Forms.ToolStripButton();
       this.tslblTimePlayed = new System.Windows.Forms.ToolStripLabel();
       this.tsbtnShowCount = new System.Windows.Forms.ToolStripButton();
       this.tsbtnRoundCount = new System.Windows.Forms.ToolStripButton();
       this.tsbtnWinCount = new System.Windows.Forms.ToolStripButton();
-      this.tsbtnWinPct = new System.Windows.Forms.ToolStripButton();
-      this.gridDetails = new FallGuysStats.Grid();
-      this.tslblKudosCount = new System.Windows.Forms.ToolStripLabel();
       this.tslblFinalPct = new System.Windows.Forms.ToolStripLabel();
+      this.tsbtnWinPct = new System.Windows.Forms.ToolStripButton();
+      this.tslblKudosCount = new System.Windows.Forms.ToolStripLabel();
       this.tsbtnGridDisplayType = new System.Windows.Forms.ToolStripSplitButton();
-      this.countsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-      this.percentagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.tsbtnCounts = new System.Windows.Forms.ToolStripMenuItem();
+      this.tsbtnPercentages = new System.Windows.Forms.ToolStripMenuItem();
       this.toolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
-      this.helpToolStripButton = new System.Windows.Forms.ToolStripButton();
-      this.tsbtnLaunchGame = new System.Windows.Forms.ToolStripButton();
+      this.tsbtnHelp = new System.Windows.Forms.ToolStripButton();
+      this.gridDetails = new FallGuysStats.Grid();
       this.menu.SuspendLayout();
       this.mainToolStrip.SuspendLayout();
       ((System.ComponentModel.ISupportInitialize)(this.gridDetails)).BeginInit();
@@ -108,7 +108,7 @@
             this.menuDayStats,
             this.menuSessionStats});
       this.menuStatsFilter.Name = "menuStatsFilter";
-      this.menuStatsFilter.Size = new System.Drawing.Size(252, 30);
+      this.menuStatsFilter.Size = new System.Drawing.Size(135, 30);
       this.menuStatsFilter.Text = "Stats";
       // 
       // menuAllStats
@@ -175,7 +175,7 @@
             this.menuSoloStats,
             this.menuPartyStats});
       this.menuPartyFilter.Name = "menuPartyFilter";
-      this.menuPartyFilter.Size = new System.Drawing.Size(252, 30);
+      this.menuPartyFilter.Size = new System.Drawing.Size(135, 30);
       this.menuPartyFilter.Text = "Party";
       // 
       // menuAllPartyStats
@@ -187,7 +187,7 @@
       this.menuAllPartyStats.Name = "menuAllPartyStats";
       this.menuAllPartyStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.F)));
-      this.menuAllPartyStats.Size = new System.Drawing.Size(252, 30);
+      this.menuAllPartyStats.Size = new System.Drawing.Size(245, 30);
       this.menuAllPartyStats.Text = "All";
       this.menuAllPartyStats.Click += new System.EventHandler(this.menuStats_Click);
       // 
@@ -198,7 +198,7 @@
       this.menuSoloStats.Name = "menuSoloStats";
       this.menuSoloStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.O)));
-      this.menuSoloStats.Size = new System.Drawing.Size(252, 30);
+      this.menuSoloStats.Size = new System.Drawing.Size(245, 30);
       this.menuSoloStats.Text = "Solo";
       this.menuSoloStats.Click += new System.EventHandler(this.menuStats_Click);
       // 
@@ -209,7 +209,7 @@
       this.menuPartyStats.Name = "menuPartyStats";
       this.menuPartyStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.P)));
-      this.menuPartyStats.Size = new System.Drawing.Size(252, 30);
+      this.menuPartyStats.Size = new System.Drawing.Size(245, 30);
       this.menuPartyStats.Text = "Party";
       this.menuPartyStats.Click += new System.EventHandler(this.menuStats_Click);
       // 
@@ -229,7 +229,7 @@
       this.menuProfileMain.CheckState = System.Windows.Forms.CheckState.Checked;
       this.menuProfileMain.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
       this.menuProfileMain.Name = "menuProfileMain";
-      this.menuProfileMain.Size = new System.Drawing.Size(252, 30);
+      this.menuProfileMain.Size = new System.Drawing.Size(156, 30);
       this.menuProfileMain.Text = "Main";
       this.menuProfileMain.Click += new System.EventHandler(this.menuStats_Click);
       // 
@@ -238,7 +238,7 @@
       this.menuProfilePractice.CheckOnClick = true;
       this.menuProfilePractice.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
       this.menuProfilePractice.Name = "menuProfilePractice";
-      this.menuProfilePractice.Size = new System.Drawing.Size(252, 30);
+      this.menuProfilePractice.Size = new System.Drawing.Size(156, 30);
       this.menuProfilePractice.Text = "Practice";
       this.menuProfilePractice.Click += new System.EventHandler(this.menuStats_Click);
       // 
@@ -283,12 +283,23 @@
             this.tslblKudosCount,
             this.tsbtnGridDisplayType,
             this.toolStripSeparator,
-            this.helpToolStripButton});
+            this.tsbtnHelp});
       this.mainToolStrip.Location = new System.Drawing.Point(0, 33);
       this.mainToolStrip.Name = "mainToolStrip";
       this.mainToolStrip.Size = new System.Drawing.Size(975, 32);
       this.mainToolStrip.TabIndex = 13;
       this.mainToolStrip.Text = "toolStrip1";
+      // 
+      // tsbtnLaunchGame
+      // 
+      this.tsbtnLaunchGame.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+      this.tsbtnLaunchGame.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnLaunchGame.Image")));
+      this.tsbtnLaunchGame.ImageTransparentColor = System.Drawing.Color.Magenta;
+      this.tsbtnLaunchGame.Name = "tsbtnLaunchGame";
+      this.tsbtnLaunchGame.Size = new System.Drawing.Size(145, 29);
+      this.tsbtnLaunchGame.Text = "Launch Fall Guys";
+      this.tsbtnLaunchGame.ToolTipText = "Launch Fall Guys";
+      this.tsbtnLaunchGame.Click += new System.EventHandler(this.tsbtnLaunchGame_Click);
       // 
       // tslblTimePlayed
       // 
@@ -305,7 +316,7 @@
       this.tsbtnShowCount.Name = "tsbtnShowCount";
       this.tsbtnShowCount.Size = new System.Drawing.Size(87, 29);
       this.tsbtnShowCount.Text = "Shows: 0";
-      this.tsbtnShowCount.Click += new System.EventHandler(this.tslblShowCount_Click);
+      this.tsbtnShowCount.Click += new System.EventHandler(this.tsbtnShowCount_Click);
       // 
       // tsbtnRoundCount
       // 
@@ -316,7 +327,7 @@
       this.tsbtnRoundCount.Name = "tsbtnRoundCount";
       this.tsbtnRoundCount.Size = new System.Drawing.Size(95, 29);
       this.tsbtnRoundCount.Text = "Rounds: 0";
-      this.tsbtnRoundCount.Click += new System.EventHandler(this.tslblRoundCount_Click);
+      this.tsbtnRoundCount.Click += new System.EventHandler(this.tsBtnRoundCount_Click);
       // 
       // tsbtnWinCount
       // 
@@ -327,7 +338,13 @@
       this.tsbtnWinCount.Name = "tsbtnWinCount";
       this.tsbtnWinCount.Size = new System.Drawing.Size(74, 29);
       this.tsbtnWinCount.Text = "Wins: 0";
-      this.tsbtnWinCount.Click += new System.EventHandler(this.tslblWinCount_Click);
+      this.tsbtnWinCount.Click += new System.EventHandler(this.tsbtnWinCount_Click);
+      // 
+      // tslblFinalPct
+      // 
+      this.tslblFinalPct.Name = "tslblFinalPct";
+      this.tslblFinalPct.Size = new System.Drawing.Size(68, 29);
+      this.tslblFinalPct.Text = "Final %";
       // 
       // tsbtnWinPct
       // 
@@ -338,7 +355,57 @@
       this.tsbtnWinPct.Name = "tsbtnWinPct";
       this.tsbtnWinPct.Size = new System.Drawing.Size(71, 29);
       this.tsbtnWinPct.Text = "Win %:";
-      this.tsbtnWinPct.Click += new System.EventHandler(this.tslblWinPct_Click);
+      this.tsbtnWinPct.Click += new System.EventHandler(this.tsbtnWinPct_Click);
+      // 
+      // tslblKudosCount
+      // 
+      this.tslblKudosCount.Name = "tslblKudosCount";
+      this.tslblKudosCount.Size = new System.Drawing.Size(62, 29);
+      this.tslblKudosCount.Text = "Kudos";
+      // 
+      // tsbtnGridDisplayType
+      // 
+      this.tsbtnGridDisplayType.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.tsbtnCounts,
+            this.tsbtnPercentages});
+      this.tsbtnGridDisplayType.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnGridDisplayType.Image")));
+      this.tsbtnGridDisplayType.ImageTransparentColor = System.Drawing.Color.Magenta;
+      this.tsbtnGridDisplayType.Name = "tsbtnGridDisplayType";
+      this.tsbtnGridDisplayType.Size = new System.Drawing.Size(153, 29);
+      this.tsbtnGridDisplayType.Text = "Grid Display";
+      this.tsbtnGridDisplayType.ToolTipText = "Switch between counts and percentages in the stats grid";
+      this.tsbtnGridDisplayType.ButtonClick += new System.EventHandler(this.tsbtnGridDisplayType_ButtonClick);
+      // 
+      // tsbtnCounts
+      // 
+      this.tsbtnCounts.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnCounts.Image")));
+      this.tsbtnCounts.Name = "tsbtnCounts";
+      this.tsbtnCounts.Size = new System.Drawing.Size(252, 30);
+      this.tsbtnCounts.Text = "Counts";
+      this.tsbtnCounts.Click += new System.EventHandler(this.tsbtnCounts_Click);
+      // 
+      // tsbtnPercentages
+      // 
+      this.tsbtnPercentages.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnPercentages.Image")));
+      this.tsbtnPercentages.Name = "tsbtnPercentages";
+      this.tsbtnPercentages.Size = new System.Drawing.Size(252, 30);
+      this.tsbtnPercentages.Text = "Percentages";
+      this.tsbtnPercentages.Click += new System.EventHandler(this.tsbtnPercentages_Click);
+      // 
+      // toolStripSeparator
+      // 
+      this.toolStripSeparator.Name = "toolStripSeparator";
+      this.toolStripSeparator.Size = new System.Drawing.Size(6, 32);
+      // 
+      // tsbtnHelp
+      // 
+      this.tsbtnHelp.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+      this.tsbtnHelp.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnHelp.Image")));
+      this.tsbtnHelp.ImageTransparentColor = System.Drawing.Color.Magenta;
+      this.tsbtnHelp.Name = "tsbtnHelp";
+      this.tsbtnHelp.Size = new System.Drawing.Size(28, 28);
+      this.tsbtnHelp.Text = "He&lp";
+      this.tsbtnHelp.Click += new System.EventHandler(this.tsbtlHelp_Click);
       // 
       // gridDetails
       // 
@@ -349,24 +416,24 @@
       this.gridDetails.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.None;
       this.gridDetails.BorderStyle = System.Windows.Forms.BorderStyle.None;
       this.gridDetails.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-      dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-      dataGridViewCellStyle1.BackColor = System.Drawing.Color.LightGray;
-      dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-      dataGridViewCellStyle1.ForeColor = System.Drawing.Color.Black;
-      dataGridViewCellStyle1.SelectionBackColor = System.Drawing.Color.Cyan;
-      dataGridViewCellStyle1.SelectionForeColor = System.Drawing.Color.Black;
-      dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-      this.gridDetails.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+      dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+      dataGridViewCellStyle3.BackColor = System.Drawing.Color.LightGray;
+      dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+      dataGridViewCellStyle3.ForeColor = System.Drawing.Color.Black;
+      dataGridViewCellStyle3.SelectionBackColor = System.Drawing.Color.Cyan;
+      dataGridViewCellStyle3.SelectionForeColor = System.Drawing.Color.Black;
+      dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+      this.gridDetails.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle3;
       this.gridDetails.ColumnHeadersHeight = 20;
       this.gridDetails.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
-      dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-      dataGridViewCellStyle2.BackColor = System.Drawing.Color.White;
-      dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-      dataGridViewCellStyle2.ForeColor = System.Drawing.Color.Black;
-      dataGridViewCellStyle2.SelectionBackColor = System.Drawing.Color.DeepSkyBlue;
-      dataGridViewCellStyle2.SelectionForeColor = System.Drawing.Color.Black;
-      dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-      this.gridDetails.DefaultCellStyle = dataGridViewCellStyle2;
+      dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+      dataGridViewCellStyle4.BackColor = System.Drawing.Color.White;
+      dataGridViewCellStyle4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+      dataGridViewCellStyle4.ForeColor = System.Drawing.Color.Black;
+      dataGridViewCellStyle4.SelectionBackColor = System.Drawing.Color.DeepSkyBlue;
+      dataGridViewCellStyle4.SelectionForeColor = System.Drawing.Color.Black;
+      dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+      this.gridDetails.DefaultCellStyle = dataGridViewCellStyle4;
       this.gridDetails.EnableHeadersVisualStyles = false;
       this.gridDetails.GridColor = System.Drawing.Color.Gray;
       this.gridDetails.Location = new System.Drawing.Point(0, 55);
@@ -382,73 +449,6 @@
       this.gridDetails.CellMouseEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.gridDetails_CellMouseEnter);
       this.gridDetails.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.gridDetails_ColumnHeaderMouseClick);
       this.gridDetails.SelectionChanged += new System.EventHandler(this.gridDetails_SelectionChanged);
-      // 
-      // tslblKudosCount
-      // 
-      this.tslblKudosCount.Name = "tslblKudosCount";
-      this.tslblKudosCount.Size = new System.Drawing.Size(62, 29);
-      this.tslblKudosCount.Text = "Kudos";
-      // 
-      // tslblFinalPct
-      // 
-      this.tslblFinalPct.Name = "tslblFinalPct";
-      this.tslblFinalPct.Size = new System.Drawing.Size(68, 29);
-      this.tslblFinalPct.Text = "Final %";
-      // 
-      // tsbtnGridDisplayType
-      // 
-      this.tsbtnGridDisplayType.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.countsToolStripMenuItem,
-            this.percentagesToolStripMenuItem});
-      this.tsbtnGridDisplayType.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnGridDisplayType.Image")));
-      this.tsbtnGridDisplayType.ImageTransparentColor = System.Drawing.Color.Magenta;
-      this.tsbtnGridDisplayType.Name = "tsbtnGridDisplayType";
-      this.tsbtnGridDisplayType.Size = new System.Drawing.Size(153, 29);
-      this.tsbtnGridDisplayType.Text = "Grid Display";
-      this.tsbtnGridDisplayType.ToolTipText = "Switch between counts and percentages in the stats grid";
-      this.tsbtnGridDisplayType.ButtonClick += new System.EventHandler(this.tsbtnGridDisplayType_ButtonClick);
-      // 
-      // countsToolStripMenuItem
-      // 
-      this.countsToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("countsToolStripMenuItem.Image")));
-      this.countsToolStripMenuItem.Name = "countsToolStripMenuItem";
-      this.countsToolStripMenuItem.Size = new System.Drawing.Size(252, 30);
-      this.countsToolStripMenuItem.Text = "Counts";
-      this.countsToolStripMenuItem.Click += new System.EventHandler(this.countsToolStripMenuItem_Click);
-      // 
-      // percentagesToolStripMenuItem
-      // 
-      this.percentagesToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("percentagesToolStripMenuItem.Image")));
-      this.percentagesToolStripMenuItem.Name = "percentagesToolStripMenuItem";
-      this.percentagesToolStripMenuItem.Size = new System.Drawing.Size(252, 30);
-      this.percentagesToolStripMenuItem.Text = "Percentages";
-      this.percentagesToolStripMenuItem.Click += new System.EventHandler(this.percentagesToolStripMenuItem_Click);
-      // 
-      // toolStripSeparator
-      // 
-      this.toolStripSeparator.Name = "toolStripSeparator";
-      this.toolStripSeparator.Size = new System.Drawing.Size(6, 32);
-      // 
-      // helpToolStripButton
-      // 
-      this.helpToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-      this.helpToolStripButton.Image = ((System.Drawing.Image)(resources.GetObject("helpToolStripButton.Image")));
-      this.helpToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-      this.helpToolStripButton.Name = "helpToolStripButton";
-      this.helpToolStripButton.Size = new System.Drawing.Size(28, 28);
-      this.helpToolStripButton.Text = "He&lp";
-      this.helpToolStripButton.Click += new System.EventHandler(this.helpToolStripButton_Click);
-      // 
-      // tsbtnLaunchGame
-      // 
-      this.tsbtnLaunchGame.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-      this.tsbtnLaunchGame.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnLaunchGame.Image")));
-      this.tsbtnLaunchGame.ImageTransparentColor = System.Drawing.Color.Magenta;
-      this.tsbtnLaunchGame.Name = "tsbtnLaunchGame";
-      this.tsbtnLaunchGame.Size = new System.Drawing.Size(145, 29);
-      this.tsbtnLaunchGame.Text = "Launch Fall Guys";
-      this.tsbtnLaunchGame.ToolTipText = "Launch Fall Guys";
-      this.tsbtnLaunchGame.Click += new System.EventHandler(this.tsbtnLaunchGame_Click);
       // 
       // Stats
       // 
@@ -510,10 +510,10 @@
         private System.Windows.Forms.ToolStripLabel tslblFinalPct;
         private System.Windows.Forms.ToolStripLabel tslblKudosCount;
         private System.Windows.Forms.ToolStripSplitButton tsbtnGridDisplayType;
-        private System.Windows.Forms.ToolStripMenuItem countsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem percentagesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem tsbtnCounts;
+        private System.Windows.Forms.ToolStripMenuItem tsbtnPercentages;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator;
-        private System.Windows.Forms.ToolStripButton helpToolStripButton;
+        private System.Windows.Forms.ToolStripButton tsbtnHelp;
         private System.Windows.Forms.ToolStripButton tsbtnLaunchGame;
     }
 }

--- a/Views/Stats.Designer.cs
+++ b/Views/Stats.Designer.cs
@@ -23,391 +23,465 @@
         /// the contents of this method with the code editor.
         /// </summary>
         private void InitializeComponent() {
-            this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Stats));
-            this.lblTotalShows = new System.Windows.Forms.Label();
-            this.lblTotalTime = new System.Windows.Forms.Label();
-            this.lblTotalRounds = new System.Windows.Forms.Label();
-            this.lblTotalWins = new System.Windows.Forms.Label();
-            this.lblFinalChance = new System.Windows.Forms.Label();
-            this.lblWinChance = new System.Windows.Forms.Label();
-            this.lblKudos = new System.Windows.Forms.Label();
-            this.menu = new System.Windows.Forms.MenuStrip();
-            this.menuSettings = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuFilters = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuStatsFilter = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuAllStats = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuSeasonStats = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuWeekStats = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuDayStats = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuSessionStats = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuPartyFilter = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuAllPartyStats = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuSoloStats = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuPartyStats = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuProfile = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuProfileMain = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuProfilePractice = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuOverlay = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuUpdate = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuHelp = new System.Windows.Forms.ToolStripMenuItem();
-            this.gridDetails = new FallGuysStats.Grid();
-            this.menu.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.gridDetails)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // lblTotalShows
-            // 
-            this.lblTotalShows.AutoSize = true;
-            this.lblTotalShows.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.lblTotalShows.ForeColor = System.Drawing.Color.Blue;
-            this.lblTotalShows.Location = new System.Drawing.Point(128, 28);
-            this.lblTotalShows.Name = "lblTotalShows";
-            this.lblTotalShows.Size = new System.Drawing.Size(51, 13);
-            this.lblTotalShows.TabIndex = 5;
-            this.lblTotalShows.Text = "Shows: 0";
-            this.lblTotalShows.Click += new System.EventHandler(this.lblTotalShows_Click);
-            // 
-            // lblTotalTime
-            // 
-            this.lblTotalTime.AutoSize = true;
-            this.lblTotalTime.Location = new System.Drawing.Point(8, 28);
-            this.lblTotalTime.Name = "lblTotalTime";
-            this.lblTotalTime.Size = new System.Drawing.Size(107, 13);
-            this.lblTotalTime.TabIndex = 4;
-            this.lblTotalTime.Text = "Time Played: 0:00:00";
-            // 
-            // lblTotalRounds
-            // 
-            this.lblTotalRounds.AutoSize = true;
-            this.lblTotalRounds.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.lblTotalRounds.ForeColor = System.Drawing.Color.Blue;
-            this.lblTotalRounds.Location = new System.Drawing.Point(206, 28);
-            this.lblTotalRounds.Name = "lblTotalRounds";
-            this.lblTotalRounds.Size = new System.Drawing.Size(56, 13);
-            this.lblTotalRounds.TabIndex = 6;
-            this.lblTotalRounds.Text = "Rounds: 0";
-            this.lblTotalRounds.Click += new System.EventHandler(this.lblTotalRounds_Click);
-            // 
-            // lblTotalWins
-            // 
-            this.lblTotalWins.AutoSize = true;
-            this.lblTotalWins.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.lblTotalWins.ForeColor = System.Drawing.Color.Blue;
-            this.lblTotalWins.Location = new System.Drawing.Point(296, 28);
-            this.lblTotalWins.Name = "lblTotalWins";
-            this.lblTotalWins.Size = new System.Drawing.Size(43, 13);
-            this.lblTotalWins.TabIndex = 7;
-            this.lblTotalWins.Text = "Wins: 0";
-            this.lblTotalWins.Click += new System.EventHandler(this.lblTotalWins_Click);
-            // 
-            // lblFinalChance
-            // 
-            this.lblFinalChance.AutoSize = true;
-            this.lblFinalChance.Location = new System.Drawing.Point(365, 28);
-            this.lblFinalChance.Name = "lblFinalChance";
-            this.lblFinalChance.Size = new System.Drawing.Size(61, 13);
-            this.lblFinalChance.TabIndex = 8;
-            this.lblFinalChance.Text = "Final %: 0.0";
-            // 
-            // lblWinChance
-            // 
-            this.lblWinChance.AutoSize = true;
-            this.lblWinChance.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.lblWinChance.ForeColor = System.Drawing.Color.Blue;
-            this.lblWinChance.Location = new System.Drawing.Point(443, 28);
-            this.lblWinChance.Name = "lblWinChance";
-            this.lblWinChance.Size = new System.Drawing.Size(58, 13);
-            this.lblWinChance.TabIndex = 9;
-            this.lblWinChance.Text = "Win %: 0.0";
-            this.lblWinChance.Click += new System.EventHandler(this.lblWinChance_Click);
-            // 
-            // lblKudos
-            // 
-            this.lblKudos.AutoSize = true;
-            this.lblKudos.Location = new System.Drawing.Point(520, 28);
-            this.lblKudos.Name = "lblKudos";
-            this.lblKudos.Size = new System.Drawing.Size(49, 13);
-            this.lblKudos.TabIndex = 10;
-            this.lblKudos.Text = "Kudos: 0";
-            // 
-            // menu
-            // 
-            this.menu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.components = new System.ComponentModel.Container();
+      System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+      System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+      System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Stats));
+      this.menu = new System.Windows.Forms.MenuStrip();
+      this.menuSettings = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuFilters = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuStatsFilter = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuAllStats = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuSeasonStats = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuWeekStats = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuDayStats = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuSessionStats = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuPartyFilter = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuAllPartyStats = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuSoloStats = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuPartyStats = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuProfile = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuProfileMain = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuProfilePractice = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuOverlay = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuUpdate = new System.Windows.Forms.ToolStripMenuItem();
+      this.menuHelp = new System.Windows.Forms.ToolStripMenuItem();
+      this.mainToolStrip = new System.Windows.Forms.ToolStrip();
+      this.tslblTimePlayed = new System.Windows.Forms.ToolStripLabel();
+      this.tsbtnShowCount = new System.Windows.Forms.ToolStripButton();
+      this.tsbtnRoundCount = new System.Windows.Forms.ToolStripButton();
+      this.tsbtnWinCount = new System.Windows.Forms.ToolStripButton();
+      this.tsbtnWinPct = new System.Windows.Forms.ToolStripButton();
+      this.gridDetails = new FallGuysStats.Grid();
+      this.tslblKudosCount = new System.Windows.Forms.ToolStripLabel();
+      this.tslblFinalPct = new System.Windows.Forms.ToolStripLabel();
+      this.tsbtnGridDisplayType = new System.Windows.Forms.ToolStripSplitButton();
+      this.countsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.percentagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.toolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+      this.helpToolStripButton = new System.Windows.Forms.ToolStripButton();
+      this.tsbtnLaunchGame = new System.Windows.Forms.ToolStripButton();
+      this.menu.SuspendLayout();
+      this.mainToolStrip.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.gridDetails)).BeginInit();
+      this.SuspendLayout();
+      // 
+      // menu
+      // 
+      this.menu.ImageScalingSize = new System.Drawing.Size(24, 24);
+      this.menu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuSettings,
             this.menuFilters,
             this.menuProfile,
             this.menuOverlay,
             this.menuUpdate,
             this.menuHelp});
-            this.menu.Location = new System.Drawing.Point(0, 0);
-            this.menu.Name = "menu";
-            this.menu.Size = new System.Drawing.Size(614, 24);
-            this.menu.TabIndex = 12;
-            this.menu.Text = "menuStrip1";
-            // 
-            // menuSettings
-            // 
-            this.menuSettings.Name = "menuSettings";
-            this.menuSettings.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.menuSettings.Size = new System.Drawing.Size(61, 20);
-            this.menuSettings.Text = "Settings";
-            this.menuSettings.Click += new System.EventHandler(this.menuSettings_Click);
-            // 
-            // menuFilters
-            // 
-            this.menuFilters.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.menu.Location = new System.Drawing.Point(0, 0);
+      this.menu.Name = "menu";
+      this.menu.Size = new System.Drawing.Size(975, 33);
+      this.menu.TabIndex = 12;
+      this.menu.Text = "menuStrip1";
+      // 
+      // menuSettings
+      // 
+      this.menuSettings.Name = "menuSettings";
+      this.menuSettings.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
+      this.menuSettings.Size = new System.Drawing.Size(88, 29);
+      this.menuSettings.Text = "Settings";
+      this.menuSettings.Click += new System.EventHandler(this.menuSettings_Click);
+      // 
+      // menuFilters
+      // 
+      this.menuFilters.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuStatsFilter,
             this.menuPartyFilter});
-            this.menuFilters.Name = "menuFilters";
-            this.menuFilters.Size = new System.Drawing.Size(50, 20);
-            this.menuFilters.Text = "Filters";
-            // 
-            // menuStatsFilter
-            // 
-            this.menuStatsFilter.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.menuFilters.Name = "menuFilters";
+      this.menuFilters.Size = new System.Drawing.Size(70, 29);
+      this.menuFilters.Text = "Filters";
+      // 
+      // menuStatsFilter
+      // 
+      this.menuStatsFilter.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuAllStats,
             this.menuSeasonStats,
             this.menuWeekStats,
             this.menuDayStats,
             this.menuSessionStats});
-            this.menuStatsFilter.Name = "menuStatsFilter";
-            this.menuStatsFilter.Size = new System.Drawing.Size(101, 22);
-            this.menuStatsFilter.Text = "Stats";
-            // 
-            // menuAllStats
-            // 
-            this.menuAllStats.Checked = true;
-            this.menuAllStats.CheckOnClick = true;
-            this.menuAllStats.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.menuAllStats.Name = "menuAllStats";
-            this.menuAllStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+      this.menuStatsFilter.Name = "menuStatsFilter";
+      this.menuStatsFilter.Size = new System.Drawing.Size(252, 30);
+      this.menuStatsFilter.Text = "Stats";
+      // 
+      // menuAllStats
+      // 
+      this.menuAllStats.Checked = true;
+      this.menuAllStats.CheckOnClick = true;
+      this.menuAllStats.CheckState = System.Windows.Forms.CheckState.Checked;
+      this.menuAllStats.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+      this.menuAllStats.Name = "menuAllStats";
+      this.menuAllStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.A)));
-            this.menuAllStats.Size = new System.Drawing.Size(187, 22);
-            this.menuAllStats.Text = "All";
-            this.menuAllStats.Click += new System.EventHandler(this.menuStats_Click);
-            // 
-            // menuSeasonStats
-            // 
-            this.menuSeasonStats.CheckOnClick = true;
-            this.menuSeasonStats.Name = "menuSeasonStats";
-            this.menuSeasonStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+      this.menuAllStats.Size = new System.Drawing.Size(267, 30);
+      this.menuAllStats.Text = "All";
+      this.menuAllStats.Click += new System.EventHandler(this.menuStats_Click);
+      // 
+      // menuSeasonStats
+      // 
+      this.menuSeasonStats.CheckOnClick = true;
+      this.menuSeasonStats.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+      this.menuSeasonStats.Name = "menuSeasonStats";
+      this.menuSeasonStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.S)));
-            this.menuSeasonStats.Size = new System.Drawing.Size(187, 22);
-            this.menuSeasonStats.Text = "Season";
-            this.menuSeasonStats.Click += new System.EventHandler(this.menuStats_Click);
-            // 
-            // menuWeekStats
-            // 
-            this.menuWeekStats.CheckOnClick = true;
-            this.menuWeekStats.Name = "menuWeekStats";
-            this.menuWeekStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+      this.menuSeasonStats.Size = new System.Drawing.Size(267, 30);
+      this.menuSeasonStats.Text = "Season";
+      this.menuSeasonStats.Click += new System.EventHandler(this.menuStats_Click);
+      // 
+      // menuWeekStats
+      // 
+      this.menuWeekStats.CheckOnClick = true;
+      this.menuWeekStats.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+      this.menuWeekStats.Name = "menuWeekStats";
+      this.menuWeekStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.W)));
-            this.menuWeekStats.Size = new System.Drawing.Size(187, 22);
-            this.menuWeekStats.Text = "Week";
-            this.menuWeekStats.Click += new System.EventHandler(this.menuStats_Click);
-            // 
-            // menuDayStats
-            // 
-            this.menuDayStats.CheckOnClick = true;
-            this.menuDayStats.Name = "menuDayStats";
-            this.menuDayStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+      this.menuWeekStats.Size = new System.Drawing.Size(267, 30);
+      this.menuWeekStats.Text = "Week";
+      this.menuWeekStats.Click += new System.EventHandler(this.menuStats_Click);
+      // 
+      // menuDayStats
+      // 
+      this.menuDayStats.CheckOnClick = true;
+      this.menuDayStats.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+      this.menuDayStats.Name = "menuDayStats";
+      this.menuDayStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.D)));
-            this.menuDayStats.Size = new System.Drawing.Size(187, 22);
-            this.menuDayStats.Text = "Day";
-            this.menuDayStats.Click += new System.EventHandler(this.menuStats_Click);
-            // 
-            // menuSessionStats
-            // 
-            this.menuSessionStats.CheckOnClick = true;
-            this.menuSessionStats.Name = "menuSessionStats";
-            this.menuSessionStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+      this.menuDayStats.Size = new System.Drawing.Size(267, 30);
+      this.menuDayStats.Text = "Day";
+      this.menuDayStats.Click += new System.EventHandler(this.menuStats_Click);
+      // 
+      // menuSessionStats
+      // 
+      this.menuSessionStats.CheckOnClick = true;
+      this.menuSessionStats.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+      this.menuSessionStats.Name = "menuSessionStats";
+      this.menuSessionStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.G)));
-            this.menuSessionStats.Size = new System.Drawing.Size(187, 22);
-            this.menuSessionStats.Text = "Session";
-            this.menuSessionStats.Click += new System.EventHandler(this.menuStats_Click);
-            // 
-            // menuPartyFilter
-            // 
-            this.menuPartyFilter.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.menuSessionStats.Size = new System.Drawing.Size(267, 30);
+      this.menuSessionStats.Text = "Session";
+      this.menuSessionStats.Click += new System.EventHandler(this.menuStats_Click);
+      // 
+      // menuPartyFilter
+      // 
+      this.menuPartyFilter.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuAllPartyStats,
             this.menuSoloStats,
             this.menuPartyStats});
-            this.menuPartyFilter.Name = "menuPartyFilter";
-            this.menuPartyFilter.Size = new System.Drawing.Size(101, 22);
-            this.menuPartyFilter.Text = "Party";
-            // 
-            // menuAllPartyStats
-            // 
-            this.menuAllPartyStats.Checked = true;
-            this.menuAllPartyStats.CheckOnClick = true;
-            this.menuAllPartyStats.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.menuAllPartyStats.Name = "menuAllPartyStats";
-            this.menuAllPartyStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+      this.menuPartyFilter.Name = "menuPartyFilter";
+      this.menuPartyFilter.Size = new System.Drawing.Size(252, 30);
+      this.menuPartyFilter.Text = "Party";
+      // 
+      // menuAllPartyStats
+      // 
+      this.menuAllPartyStats.Checked = true;
+      this.menuAllPartyStats.CheckOnClick = true;
+      this.menuAllPartyStats.CheckState = System.Windows.Forms.CheckState.Checked;
+      this.menuAllPartyStats.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+      this.menuAllPartyStats.Name = "menuAllPartyStats";
+      this.menuAllPartyStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.F)));
-            this.menuAllPartyStats.Size = new System.Drawing.Size(174, 22);
-            this.menuAllPartyStats.Text = "All";
-            this.menuAllPartyStats.Click += new System.EventHandler(this.menuStats_Click);
-            // 
-            // menuSoloStats
-            // 
-            this.menuSoloStats.CheckOnClick = true;
-            this.menuSoloStats.Name = "menuSoloStats";
-            this.menuSoloStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+      this.menuAllPartyStats.Size = new System.Drawing.Size(252, 30);
+      this.menuAllPartyStats.Text = "All";
+      this.menuAllPartyStats.Click += new System.EventHandler(this.menuStats_Click);
+      // 
+      // menuSoloStats
+      // 
+      this.menuSoloStats.CheckOnClick = true;
+      this.menuSoloStats.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+      this.menuSoloStats.Name = "menuSoloStats";
+      this.menuSoloStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.O)));
-            this.menuSoloStats.Size = new System.Drawing.Size(174, 22);
-            this.menuSoloStats.Text = "Solo";
-            this.menuSoloStats.Click += new System.EventHandler(this.menuStats_Click);
-            // 
-            // menuPartyStats
-            // 
-            this.menuPartyStats.CheckOnClick = true;
-            this.menuPartyStats.Name = "menuPartyStats";
-            this.menuPartyStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+      this.menuSoloStats.Size = new System.Drawing.Size(252, 30);
+      this.menuSoloStats.Text = "Solo";
+      this.menuSoloStats.Click += new System.EventHandler(this.menuStats_Click);
+      // 
+      // menuPartyStats
+      // 
+      this.menuPartyStats.CheckOnClick = true;
+      this.menuPartyStats.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+      this.menuPartyStats.Name = "menuPartyStats";
+      this.menuPartyStats.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.P)));
-            this.menuPartyStats.Size = new System.Drawing.Size(174, 22);
-            this.menuPartyStats.Text = "Party";
-            this.menuPartyStats.Click += new System.EventHandler(this.menuStats_Click);
-            // 
-            // menuProfile
-            // 
-            this.menuProfile.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+      this.menuPartyStats.Size = new System.Drawing.Size(252, 30);
+      this.menuPartyStats.Text = "Party";
+      this.menuPartyStats.Click += new System.EventHandler(this.menuStats_Click);
+      // 
+      // menuProfile
+      // 
+      this.menuProfile.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuProfileMain,
             this.menuProfilePractice});
-            this.menuProfile.Name = "menuProfile";
-            this.menuProfile.Size = new System.Drawing.Size(53, 20);
-            this.menuProfile.Text = "Profile";
-            // 
-            // menuProfileMain
-            // 
-            this.menuProfileMain.Checked = true;
-            this.menuProfileMain.CheckOnClick = true;
-            this.menuProfileMain.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.menuProfileMain.Name = "menuProfileMain";
-            this.menuProfileMain.Size = new System.Drawing.Size(116, 22);
-            this.menuProfileMain.Text = "Main";
-            this.menuProfileMain.Click += new System.EventHandler(this.menuStats_Click);
-            // 
-            // menuProfilePractice
-            // 
-            this.menuProfilePractice.CheckOnClick = true;
-            this.menuProfilePractice.Name = "menuProfilePractice";
-            this.menuProfilePractice.Size = new System.Drawing.Size(116, 22);
-            this.menuProfilePractice.Text = "Practice";
-            this.menuProfilePractice.Click += new System.EventHandler(this.menuStats_Click);
-            // 
-            // menuOverlay
-            // 
-            this.menuOverlay.Name = "menuOverlay";
-            this.menuOverlay.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.menuOverlay.Size = new System.Drawing.Size(59, 20);
-            this.menuOverlay.Text = "Overlay";
-            this.menuOverlay.Click += new System.EventHandler(this.menuOverlay_Click);
-            // 
-            // menuUpdate
-            // 
-            this.menuUpdate.Name = "menuUpdate";
-            this.menuUpdate.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.U)));
-            this.menuUpdate.Size = new System.Drawing.Size(57, 20);
-            this.menuUpdate.Text = "Update";
-            this.menuUpdate.Click += new System.EventHandler(this.menuUpdate_Click);
-            // 
-            // menuHelp
-            // 
-            this.menuHelp.Name = "menuHelp";
-            this.menuHelp.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.H)));
-            this.menuHelp.Size = new System.Drawing.Size(44, 20);
-            this.menuHelp.Text = "Help";
-            this.menuHelp.Click += new System.EventHandler(this.menuHelp_Click);
-            // 
-            // gridDetails
-            // 
-            this.gridDetails.AllowUserToDeleteRows = false;
-            this.gridDetails.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+      this.menuProfile.Name = "menuProfile";
+      this.menuProfile.Size = new System.Drawing.Size(74, 29);
+      this.menuProfile.Text = "Profile";
+      // 
+      // menuProfileMain
+      // 
+      this.menuProfileMain.Checked = true;
+      this.menuProfileMain.CheckOnClick = true;
+      this.menuProfileMain.CheckState = System.Windows.Forms.CheckState.Checked;
+      this.menuProfileMain.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+      this.menuProfileMain.Name = "menuProfileMain";
+      this.menuProfileMain.Size = new System.Drawing.Size(252, 30);
+      this.menuProfileMain.Text = "Main";
+      this.menuProfileMain.Click += new System.EventHandler(this.menuStats_Click);
+      // 
+      // menuProfilePractice
+      // 
+      this.menuProfilePractice.CheckOnClick = true;
+      this.menuProfilePractice.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+      this.menuProfilePractice.Name = "menuProfilePractice";
+      this.menuProfilePractice.Size = new System.Drawing.Size(252, 30);
+      this.menuProfilePractice.Text = "Practice";
+      this.menuProfilePractice.Click += new System.EventHandler(this.menuStats_Click);
+      // 
+      // menuOverlay
+      // 
+      this.menuOverlay.Name = "menuOverlay";
+      this.menuOverlay.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
+      this.menuOverlay.Size = new System.Drawing.Size(84, 29);
+      this.menuOverlay.Text = "Overlay";
+      this.menuOverlay.Click += new System.EventHandler(this.menuOverlay_Click);
+      // 
+      // menuUpdate
+      // 
+      this.menuUpdate.Name = "menuUpdate";
+      this.menuUpdate.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.U)));
+      this.menuUpdate.Size = new System.Drawing.Size(82, 29);
+      this.menuUpdate.Text = "Update";
+      this.menuUpdate.Click += new System.EventHandler(this.menuUpdate_Click);
+      // 
+      // menuHelp
+      // 
+      this.menuHelp.Name = "menuHelp";
+      this.menuHelp.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.H)));
+      this.menuHelp.Size = new System.Drawing.Size(61, 29);
+      this.menuHelp.Text = "Help";
+      this.menuHelp.Click += new System.EventHandler(this.menuHelp_Click);
+      // 
+      // mainToolStrip
+      // 
+      this.mainToolStrip.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(242)))), ((int)(((byte)(251)))));
+      this.mainToolStrip.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
+      this.mainToolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+      this.mainToolStrip.ImageScalingSize = new System.Drawing.Size(24, 24);
+      this.mainToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.tsbtnLaunchGame,
+            this.tslblTimePlayed,
+            this.tsbtnShowCount,
+            this.tsbtnRoundCount,
+            this.tsbtnWinCount,
+            this.tslblFinalPct,
+            this.tsbtnWinPct,
+            this.tslblKudosCount,
+            this.tsbtnGridDisplayType,
+            this.toolStripSeparator,
+            this.helpToolStripButton});
+      this.mainToolStrip.Location = new System.Drawing.Point(0, 33);
+      this.mainToolStrip.Name = "mainToolStrip";
+      this.mainToolStrip.Size = new System.Drawing.Size(975, 32);
+      this.mainToolStrip.TabIndex = 13;
+      this.mainToolStrip.Text = "toolStrip1";
+      // 
+      // tslblTimePlayed
+      // 
+      this.tslblTimePlayed.Name = "tslblTimePlayed";
+      this.tslblTimePlayed.Size = new System.Drawing.Size(174, 29);
+      this.tslblTimePlayed.Text = "Time Played: 0:00:00";
+      // 
+      // tsbtnShowCount
+      // 
+      this.tsbtnShowCount.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+      this.tsbtnShowCount.ForeColor = System.Drawing.Color.MediumBlue;
+      this.tsbtnShowCount.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnShowCount.Image")));
+      this.tsbtnShowCount.ImageTransparentColor = System.Drawing.Color.Magenta;
+      this.tsbtnShowCount.Name = "tsbtnShowCount";
+      this.tsbtnShowCount.Size = new System.Drawing.Size(87, 29);
+      this.tsbtnShowCount.Text = "Shows: 0";
+      this.tsbtnShowCount.Click += new System.EventHandler(this.tslblShowCount_Click);
+      // 
+      // tsbtnRoundCount
+      // 
+      this.tsbtnRoundCount.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+      this.tsbtnRoundCount.ForeColor = System.Drawing.Color.MediumBlue;
+      this.tsbtnRoundCount.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnRoundCount.Image")));
+      this.tsbtnRoundCount.ImageTransparentColor = System.Drawing.Color.Magenta;
+      this.tsbtnRoundCount.Name = "tsbtnRoundCount";
+      this.tsbtnRoundCount.Size = new System.Drawing.Size(95, 29);
+      this.tsbtnRoundCount.Text = "Rounds: 0";
+      this.tsbtnRoundCount.Click += new System.EventHandler(this.tslblRoundCount_Click);
+      // 
+      // tsbtnWinCount
+      // 
+      this.tsbtnWinCount.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+      this.tsbtnWinCount.ForeColor = System.Drawing.Color.MediumBlue;
+      this.tsbtnWinCount.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnWinCount.Image")));
+      this.tsbtnWinCount.ImageTransparentColor = System.Drawing.Color.Magenta;
+      this.tsbtnWinCount.Name = "tsbtnWinCount";
+      this.tsbtnWinCount.Size = new System.Drawing.Size(74, 29);
+      this.tsbtnWinCount.Text = "Wins: 0";
+      this.tsbtnWinCount.Click += new System.EventHandler(this.tslblWinCount_Click);
+      // 
+      // tsbtnWinPct
+      // 
+      this.tsbtnWinPct.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+      this.tsbtnWinPct.ForeColor = System.Drawing.Color.MediumBlue;
+      this.tsbtnWinPct.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnWinPct.Image")));
+      this.tsbtnWinPct.ImageTransparentColor = System.Drawing.Color.Magenta;
+      this.tsbtnWinPct.Name = "tsbtnWinPct";
+      this.tsbtnWinPct.Size = new System.Drawing.Size(71, 29);
+      this.tsbtnWinPct.Text = "Win %:";
+      this.tsbtnWinPct.Click += new System.EventHandler(this.tslblWinPct_Click);
+      // 
+      // gridDetails
+      // 
+      this.gridDetails.AllowUserToDeleteRows = false;
+      this.gridDetails.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.gridDetails.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.None;
-            this.gridDetails.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.gridDetails.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle1.BackColor = System.Drawing.Color.LightGray;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle1.ForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.Color.Cyan;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.gridDetails.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
-            this.gridDetails.ColumnHeadersHeight = 20;
-            this.gridDetails.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle2.BackColor = System.Drawing.Color.White;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.Color.DeepSkyBlue;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.gridDetails.DefaultCellStyle = dataGridViewCellStyle2;
-            this.gridDetails.EnableHeadersVisualStyles = false;
-            this.gridDetails.GridColor = System.Drawing.Color.Gray;
-            this.gridDetails.Location = new System.Drawing.Point(0, 50);
-            this.gridDetails.Name = "gridDetails";
-            this.gridDetails.ReadOnly = true;
-            this.gridDetails.RowHeadersVisible = false;
-            this.gridDetails.Size = new System.Drawing.Size(614, 570);
-            this.gridDetails.TabIndex = 11;
-            this.gridDetails.TabStop = false;
-            this.gridDetails.DataSourceChanged += new System.EventHandler(this.gridDetails_DataSourceChanged);
-            this.gridDetails.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.gridDetails_CellClick);
-            this.gridDetails.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.gridDetails_CellFormatting);
-            this.gridDetails.CellMouseEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.gridDetails_CellMouseEnter);
-            this.gridDetails.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.gridDetails_ColumnHeaderMouseClick);
-            this.gridDetails.SelectionChanged += new System.EventHandler(this.gridDetails_SelectionChanged);
-            // 
-            // Stats
-            // 
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(242)))), ((int)(((byte)(251)))));
-            this.ClientSize = new System.Drawing.Size(614, 620);
-            this.Controls.Add(this.lblKudos);
-            this.Controls.Add(this.lblWinChance);
-            this.Controls.Add(this.lblTotalTime);
-            this.Controls.Add(this.lblFinalChance);
-            this.Controls.Add(this.lblTotalShows);
-            this.Controls.Add(this.lblTotalWins);
-            this.Controls.Add(this.lblTotalRounds);
-            this.Controls.Add(this.gridDetails);
-            this.Controls.Add(this.menu);
-            this.DoubleBuffered = true;
-            this.ForeColor = System.Drawing.Color.Black;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MainMenuStrip = this.menu;
-            this.MinimumSize = new System.Drawing.Size(630, 300);
-            this.Name = "Stats";
-            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Fall Guys Stats";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Stats_FormClosing);
-            this.Load += new System.EventHandler(this.Stats_Load);
-            this.Shown += new System.EventHandler(this.Stats_Shown);
-            this.menu.ResumeLayout(false);
-            this.menu.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.gridDetails)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+      this.gridDetails.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.None;
+      this.gridDetails.BorderStyle = System.Windows.Forms.BorderStyle.None;
+      this.gridDetails.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
+      dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+      dataGridViewCellStyle1.BackColor = System.Drawing.Color.LightGray;
+      dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+      dataGridViewCellStyle1.ForeColor = System.Drawing.Color.Black;
+      dataGridViewCellStyle1.SelectionBackColor = System.Drawing.Color.Cyan;
+      dataGridViewCellStyle1.SelectionForeColor = System.Drawing.Color.Black;
+      dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+      this.gridDetails.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+      this.gridDetails.ColumnHeadersHeight = 20;
+      this.gridDetails.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
+      dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+      dataGridViewCellStyle2.BackColor = System.Drawing.Color.White;
+      dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+      dataGridViewCellStyle2.ForeColor = System.Drawing.Color.Black;
+      dataGridViewCellStyle2.SelectionBackColor = System.Drawing.Color.DeepSkyBlue;
+      dataGridViewCellStyle2.SelectionForeColor = System.Drawing.Color.Black;
+      dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+      this.gridDetails.DefaultCellStyle = dataGridViewCellStyle2;
+      this.gridDetails.EnableHeadersVisualStyles = false;
+      this.gridDetails.GridColor = System.Drawing.Color.Gray;
+      this.gridDetails.Location = new System.Drawing.Point(0, 55);
+      this.gridDetails.Name = "gridDetails";
+      this.gridDetails.ReadOnly = true;
+      this.gridDetails.RowHeadersVisible = false;
+      this.gridDetails.Size = new System.Drawing.Size(975, 785);
+      this.gridDetails.TabIndex = 11;
+      this.gridDetails.TabStop = false;
+      this.gridDetails.DataSourceChanged += new System.EventHandler(this.gridDetails_DataSourceChanged);
+      this.gridDetails.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.gridDetails_CellClick);
+      this.gridDetails.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.gridDetails_CellFormatting);
+      this.gridDetails.CellMouseEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.gridDetails_CellMouseEnter);
+      this.gridDetails.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.gridDetails_ColumnHeaderMouseClick);
+      this.gridDetails.SelectionChanged += new System.EventHandler(this.gridDetails_SelectionChanged);
+      // 
+      // tslblKudosCount
+      // 
+      this.tslblKudosCount.Name = "tslblKudosCount";
+      this.tslblKudosCount.Size = new System.Drawing.Size(62, 29);
+      this.tslblKudosCount.Text = "Kudos";
+      // 
+      // tslblFinalPct
+      // 
+      this.tslblFinalPct.Name = "tslblFinalPct";
+      this.tslblFinalPct.Size = new System.Drawing.Size(68, 29);
+      this.tslblFinalPct.Text = "Final %";
+      // 
+      // tsbtnGridDisplayType
+      // 
+      this.tsbtnGridDisplayType.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.countsToolStripMenuItem,
+            this.percentagesToolStripMenuItem});
+      this.tsbtnGridDisplayType.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnGridDisplayType.Image")));
+      this.tsbtnGridDisplayType.ImageTransparentColor = System.Drawing.Color.Magenta;
+      this.tsbtnGridDisplayType.Name = "tsbtnGridDisplayType";
+      this.tsbtnGridDisplayType.Size = new System.Drawing.Size(153, 29);
+      this.tsbtnGridDisplayType.Text = "Grid Display";
+      this.tsbtnGridDisplayType.ToolTipText = "Switch between counts and percentages in the stats grid";
+      this.tsbtnGridDisplayType.ButtonClick += new System.EventHandler(this.tsbtnGridDisplayType_ButtonClick);
+      // 
+      // countsToolStripMenuItem
+      // 
+      this.countsToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("countsToolStripMenuItem.Image")));
+      this.countsToolStripMenuItem.Name = "countsToolStripMenuItem";
+      this.countsToolStripMenuItem.Size = new System.Drawing.Size(252, 30);
+      this.countsToolStripMenuItem.Text = "Counts";
+      this.countsToolStripMenuItem.Click += new System.EventHandler(this.countsToolStripMenuItem_Click);
+      // 
+      // percentagesToolStripMenuItem
+      // 
+      this.percentagesToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("percentagesToolStripMenuItem.Image")));
+      this.percentagesToolStripMenuItem.Name = "percentagesToolStripMenuItem";
+      this.percentagesToolStripMenuItem.Size = new System.Drawing.Size(252, 30);
+      this.percentagesToolStripMenuItem.Text = "Percentages";
+      this.percentagesToolStripMenuItem.Click += new System.EventHandler(this.percentagesToolStripMenuItem_Click);
+      // 
+      // toolStripSeparator
+      // 
+      this.toolStripSeparator.Name = "toolStripSeparator";
+      this.toolStripSeparator.Size = new System.Drawing.Size(6, 32);
+      // 
+      // helpToolStripButton
+      // 
+      this.helpToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+      this.helpToolStripButton.Image = ((System.Drawing.Image)(resources.GetObject("helpToolStripButton.Image")));
+      this.helpToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+      this.helpToolStripButton.Name = "helpToolStripButton";
+      this.helpToolStripButton.Size = new System.Drawing.Size(28, 28);
+      this.helpToolStripButton.Text = "He&lp";
+      this.helpToolStripButton.Click += new System.EventHandler(this.helpToolStripButton_Click);
+      // 
+      // tsbtnLaunchGame
+      // 
+      this.tsbtnLaunchGame.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+      this.tsbtnLaunchGame.Image = ((System.Drawing.Image)(resources.GetObject("tsbtnLaunchGame.Image")));
+      this.tsbtnLaunchGame.ImageTransparentColor = System.Drawing.Color.Magenta;
+      this.tsbtnLaunchGame.Name = "tsbtnLaunchGame";
+      this.tsbtnLaunchGame.Size = new System.Drawing.Size(145, 29);
+      this.tsbtnLaunchGame.Text = "Launch Fall Guys";
+      this.tsbtnLaunchGame.ToolTipText = "Launch Fall Guys";
+      this.tsbtnLaunchGame.Click += new System.EventHandler(this.tsbtnLaunchGame_Click);
+      // 
+      // Stats
+      // 
+      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+      this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(242)))), ((int)(((byte)(251)))));
+      this.ClientSize = new System.Drawing.Size(975, 853);
+      this.Controls.Add(this.mainToolStrip);
+      this.Controls.Add(this.gridDetails);
+      this.Controls.Add(this.menu);
+      this.DoubleBuffered = true;
+      this.ForeColor = System.Drawing.Color.Black;
+      this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+      this.MainMenuStrip = this.menu;
+      this.MinimumSize = new System.Drawing.Size(630, 300);
+      this.Name = "Stats";
+      this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+      this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+      this.Text = "Fall Guys Stats";
+      this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Stats_FormClosing);
+      this.Load += new System.EventHandler(this.Stats_Load);
+      this.Shown += new System.EventHandler(this.Stats_Shown);
+      this.menu.ResumeLayout(false);
+      this.menu.PerformLayout();
+      this.mainToolStrip.ResumeLayout(false);
+      this.mainToolStrip.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.gridDetails)).EndInit();
+      this.ResumeLayout(false);
+      this.PerformLayout();
 
         }
 
         #endregion
         private Grid gridDetails;
-        private System.Windows.Forms.Label lblTotalShows;
-        private System.Windows.Forms.Label lblTotalTime;
-        private System.Windows.Forms.Label lblTotalRounds;
-        private System.Windows.Forms.Label lblTotalWins;
-        private System.Windows.Forms.Label lblFinalChance;
-        private System.Windows.Forms.Label lblWinChance;
-        private System.Windows.Forms.Label lblKudos;
         private System.Windows.Forms.MenuStrip menu;
         private System.Windows.Forms.ToolStripMenuItem menuSettings;
         private System.Windows.Forms.ToolStripMenuItem menuFilters;
@@ -427,6 +501,20 @@
         private System.Windows.Forms.ToolStripMenuItem menuProfile;
         private System.Windows.Forms.ToolStripMenuItem menuProfileMain;
         private System.Windows.Forms.ToolStripMenuItem menuProfilePractice;
+        private System.Windows.Forms.ToolStrip mainToolStrip;
+        private System.Windows.Forms.ToolStripLabel tslblTimePlayed;
+        private System.Windows.Forms.ToolStripButton tsbtnShowCount;
+        private System.Windows.Forms.ToolStripButton tsbtnRoundCount;
+        private System.Windows.Forms.ToolStripButton tsbtnWinCount;
+        private System.Windows.Forms.ToolStripButton tsbtnWinPct;
+        private System.Windows.Forms.ToolStripLabel tslblFinalPct;
+        private System.Windows.Forms.ToolStripLabel tslblKudosCount;
+        private System.Windows.Forms.ToolStripSplitButton tsbtnGridDisplayType;
+        private System.Windows.Forms.ToolStripMenuItem countsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem percentagesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator;
+        private System.Windows.Forms.ToolStripButton helpToolStripButton;
+        private System.Windows.Forms.ToolStripButton tsbtnLaunchGame;
     }
 }
 

--- a/Views/Stats.cs
+++ b/Views/Stats.cs
@@ -1017,22 +1017,7 @@ namespace FallGuysStats {
                 gridDetails.ClearSelection();
             }
         }
-        private void lblWinChance_Click(object sender, EventArgs e) {
-            ToggleWinPercentageDisplay();
-        }
-
-        private void lblTotalShows_Click(object sender, EventArgs e) {
-            ShowShows();
-        }
-
-        private void lblTotalRounds_Click(object sender, EventArgs e) {
-            ShowRounds();
-        }
-
-        private void lblTotalWins_Click(object sender, EventArgs e) {
-            ShowWinGraph();
-        }
-
+        
         private void menuStats_Click(object sender, EventArgs e) {
             try {
                 ToolStripMenuItem button = sender as ToolStripMenuItem;
@@ -1236,27 +1221,28 @@ namespace FallGuysStats {
             }
         }
 
-        private void tslblRoundCount_Click(object sender, EventArgs e) {
+        #region Tool Strip click handlers
+        private void tsBtnRoundCount_Click(object sender, EventArgs e) {
             ShowRounds();
         }
 
-        private void tslblShowCount_Click(object sender, EventArgs e) {
+        private void tsbtnShowCount_Click(object sender, EventArgs e) {
             ShowShows();
         }
 
-        private void tslblWinCount_Click(object sender, EventArgs e) {
+        private void tsbtnWinCount_Click(object sender, EventArgs e) {
             ShowWinGraph();
         }
 
-        private void tslblWinPct_Click(object sender, EventArgs e) {
+        private void tsbtnWinPct_Click(object sender, EventArgs e) {
             ToggleWinPercentageDisplay();
         }
 
-        private void countsToolStripMenuItem_Click(object sender, EventArgs e) {
+        private void tsbtnCounts_Click(object sender, EventArgs e) {
             SetWinPercentageDisplay(false);
         }
 
-        private void percentagesToolStripMenuItem_Click(object sender, EventArgs e) {
+        private void tsbtnPercentages_Click(object sender, EventArgs e) {
             SetWinPercentageDisplay(true);
         }
 
@@ -1264,23 +1250,17 @@ namespace FallGuysStats {
             ToggleWinPercentageDisplay();
         }
 
-        private void helpToolStripButton_Click(object sender, EventArgs e) {
-            LaunchHelpInBrowser();
-        }
-
-        private void menuHelp_Click(object sender, EventArgs e) {
+        private void tsbtlHelp_Click(object sender, EventArgs e) {
             LaunchHelpInBrowser();
         }
 
         private void tsbtnLaunchGame_Click(object sender, EventArgs e) {
-            if (string.IsNullOrEmpty(CurrentSettings.GameExeLocation)) {
-                CurrentSettings.GameExeLocation = FindGameExeLocation();
-            }
-            if ((gameProcess == null) && !string.IsNullOrEmpty(CurrentSettings.GameExeLocation)) {
-                gameProcess = Process.Start(CurrentSettings.GameExeLocation);
-            } else {
-                MessageBox.Show("Fall Guys is already running.", "Already Running", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
+            LaunchGame();
+        }
+        #endregion
+
+        private void menuHelp_Click(object sender, EventArgs e) {
+            LaunchHelpInBrowser();
         }
 
         private string FindGameExeLocation() {
@@ -1492,6 +1472,19 @@ namespace FallGuysStats {
                 Process.Start(@"https://github.com/ShootMe/FallGuysStats");
             } catch (Exception ex) {
                 MessageBox.Show(this, ex.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void LaunchGame() {
+            if (string.IsNullOrEmpty(CurrentSettings.GameExeLocation)) {
+                CurrentSettings.GameExeLocation = FindGameExeLocation();
+            }
+
+            if (((gameProcess == null) || gameProcess.HasExited)
+                && !string.IsNullOrEmpty(CurrentSettings.GameExeLocation)) {
+                gameProcess = Process.Start(CurrentSettings.GameExeLocation);
+            } else {
+                MessageBox.Show("Fall Guys is already running.", "Already Running", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
     }

--- a/Views/Stats.resx
+++ b/Views/Stats.resx
@@ -120,7 +120,130 @@
   <metadata name="menu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="mainToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>125, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="tsbtnLaunchGame.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="tsbtnShowCount.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="tsbtnRoundCount.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="tsbtnWinCount.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="tsbtnWinPct.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="tsbtnGridDisplayType.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAADESURBVDhPzZG9DcMgEEYZKTO4Zwt6VkhFm43o6VkipnAi
+        Ay3Jhww6rIuVnyYnPdtwfA8sRM65/EIVTNP0FYPgttw/4s8EUsqyrrGkmCr45kKUQeC9rwNjTG1orct8
+        ndlgYxBQqOToJF0QQihKqYI3FQD8DhcGgwADSGj4bQEeOC4NNpxzVcz1QBfgFJwEt9MkWMchUDHGE53E
+        rSBMJbQPapAWJtvO2BEhKrHW9v5LwZ52ErDvbbHjei68tEBK6bxNkxLiARKe5p5LgQ/yAAAAAElFTkSu
+        QmCC
+</value>
+  </data>
+  <data name="helpToolStripButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAIVSURBVDhPtVJNaxNRFM1PyE+Yn1AUXLjK0uWgDWQZwUUX
+        KsGFBEEcCkIwqBEpGiydsSo2kupsasdo7Yi2toh0sFZjG5JpiZo20/TpVOmH5njvm8BYahEXHji8+968
+        c+55l4n8F0zM+rhVWkHmdg29A/PoK1Yw8uIjOp/3xpvqBgrjLeilZbjNLXxZ34bwt6jexMVCGRndQenl
+        0p+NWHzPXoP3rQ3bAbQhQM0E5Np2BKprbZzrm8TIs8puE+68+r0NwwZiacCwALEBCVcAqet8JlAjk1PZ
+        JzsNJt6u4+FMS3ZmMV9mmFNAMhesbBZLC6oFdOsd8oVXocmdx018Ej9k1FgqiJ0zgS6qlR6BVI4iEFRN
+        IJlxMF/1cfTMcGiQvbskB6ZqgairJ6BCTJKYu9tlAUW1oSRsNDwfB+JXQ4PzN6s07W0ZPxDS5aSgJEFn
+        06Y9CaOqSauJRvMr9qmXQ4P8/RoWvU16eyBUEq5kbigwiKoOMTBQ0zbKlTq6TxihwejkZ1iOJwfEwmiC
+        BQ49yaW50J7Fh0xJw3IxbM3hwo2x0ICRHZzFgveTunYERK5lgo5YMxx8WPFw5Li+U8wYm66jNz+Naov+
+        Beqiao58N5NrPluoryJO0QeKU7sNGKPPazh9aRzGo/eYmVvEMk270fTlmzl2N3XW9xL/jv7iaxw7+wAH
+        E9ew//AVxE8OItv/9O/Cf0ck8gud2vKswuxNZgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="countsToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAACASURBVDhPpY1RDoAgDEM5G/c/D78zHZQUESa65JnSvNRk
+        Zr+on3bIpRQjlO4dz/O9gJRznga043mmRN4MKF1QKEfdMADhhGlAoRB1fUBZyfpXZXgAlZXtwEqOumEA
+        wgnTgEIh6vqAovKuIxSclsMBuAC5ftpRJng/dTzPlL5h6QJmpvUnzSQfRAAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="percentagesToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAFwSURBVDhPpZOtbgJREIV5hD7CPkIfgeBJatfj8SgUlqwn
+        WbmyAg8ahcGDBoHD3p7v7ExZ0qamkxyYO2f+790R8ng8xsJZKAH0D5MS6W/CPThwDMrk++12K/P5vEwm
+        EwMdG1z4LLfbrbnL5YJ97GBEh8/VamUSp67rrGODE6rr9Xqv67psNhvbIrQXGYYBe+FIB9PplDNttwRy
+        jq6qCO1FBieI7EthjY4NjpYJpjv4CHvKLwnaHAkOnfbRBToCjOb9OAEVaFs62/e8s9msnE4nJzocDi6A
+        HV+Sshcn0Y9nxHGxWBjou93OSUHeAFz65pJJUFEVIgMIBjiyA7qJMah6zCLSS45BklbwLUAQ0DSNnXAO
+        HZ9ldgHnBEPBibcwuLZhgvWfCWSoCCIYJ52peM6logt75sdH+o8EeyoN5uUb+F4yneVLjY6er1KHMQuD
+        ZIE6+9Ho30smAA68XGOKDi9fY5gtOAosOHn0PriU8g+U0Rd6rYSyOL7kTQAAAABJRU5ErkJggg==
+</value>
+  </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAEAQEAAAAEAIAAoQgAAFgAAACgAAABAAAAAgAAAAAEAIAAAAAAAAEIAAAAAAAAAAAAAAAAAAAAA

--- a/Views/Stats.resx
+++ b/Views/Stats.resx
@@ -199,6 +199,26 @@
         TgDQASA1MVpwzwAAAABJRU5ErkJggg==
 </value>
   </data>
+  <data name="tsbtnCounts.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        xAAADsQBlSsOGwAAAIBJREFUOE+ljVEOgCAMQzkb9z8PvzMdlBQRJrrkmdK81GRmv6ifdsilFCOU7h3P
+        872AlHOeBrTjeaZE3gwoXVAoR90wAOGEaUChEHV9QFnJ+ldleACVle3ASo66YQDCCdOAQiHq+oCi8q4j
+        FJyWwwG4ALl+2lEmeD91PM+UvmHpAmam9SfNJB9EAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="tsbtnPercentages.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        xAAADsQBlSsOGwAAAXBJREFUOE+lk61uAlEQhXmEPsI+Qh+B4Elq1+PxKBSWrCdZubICDxqFwYMGgcPe
+        nu/sTFnSpqaTHJg7Z/7v3RHyeDzGwlkoAfQPkxLpb8I9OHAMyuT77XYr8/m8TCYTAx0bXPgst9utucvl
+        gn3sYESHz9VqZRKnruusY4MTquv1eq/rumw2G9sitBcZhgF74UgH0+mUM223BHKOrqoI7UUGJ4jsS2GN
+        jg2OlgmmO/gIe8ovCdocCQ6d9tEFOgKM5v04ARVoWzrb97yz2aycTicnOhwOLoAdX5KyFyfRj2fEcbFY
+        GOi73c5JQd4AXPrmkklQURUiAwgGOLIDuokxqHrMItJLjkGSVvAtQBDQNI2dcA4dn2V2AecEQ8GJtzC4
+        tmGC9Z8JZKgIIhgnnal4zqWiC3vmx0f6jwR7Kg3m5Rv4XjKd5UuNjp6vUocxC4NkgTr70ejfSyYADrxc
+        Y4oOL19jmC04Ciw4efQ+uJTyD5TRF3qthLI4vuRNAAAAAElFTkSuQmCC
+</value>
+  </data>
   <data name="tsbtnGridDisplayType.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -209,7 +229,7 @@
         QmCC
 </value>
   </data>
-  <data name="helpToolStripButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="tsbtnHelp.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
         YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAIVSURBVDhPtVJNaxNRFM1PyE+Yn1AUXLjK0uWgDWQZwUUX
@@ -222,26 +242,6 @@
         BQ49yaW50J7Fh0xJw3IxbM3hwo2x0ICRHZzFgveTunYERK5lgo5YMxx8WPFw5Li+U8wYm66jNz+Naov+
         Beqiao58N5NrPluoryJO0QeKU7sNGKPPazh9aRzGo/eYmVvEMk270fTlmzl2N3XW9xL/jv7iaxw7+wAH
         E9ew//AVxE8OItv/9O/Cf0ck8gud2vKswuxNZgAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="countsToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAACASURBVDhPpY1RDoAgDEM5G/c/D78zHZQUESa65JnSvNRk
-        Zr+on3bIpRQjlO4dz/O9gJRznga043mmRN4MKF1QKEfdMADhhGlAoRB1fUBZyfpXZXgAlZXtwEqOumEA
-        wgnTgEIh6vqAovKuIxSclsMBuAC5ftpRJng/dTzPlL5h6QJmpvUnzSQfRAAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="percentagesToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAFwSURBVDhPpZOtbgJREIV5hD7CPkIfgeBJatfj8SgUlqwn
-        WbmyAg8ahcGDBoHD3p7v7ExZ0qamkxyYO2f+790R8ng8xsJZKAH0D5MS6W/CPThwDMrk++12K/P5vEwm
-        EwMdG1z4LLfbrbnL5YJ97GBEh8/VamUSp67rrGODE6rr9Xqv67psNhvbIrQXGYYBe+FIB9PplDNttwRy
-        jq6qCO1FBieI7EthjY4NjpYJpjv4CHvKLwnaHAkOnfbRBToCjOb9OAEVaFs62/e8s9msnE4nJzocDi6A
-        HV+Sshcn0Y9nxHGxWBjou93OSUHeAFz65pJJUFEVIgMIBjiyA7qJMah6zCLSS45BklbwLUAQ0DSNnXAO
-        HZ9ldgHnBEPBibcwuLZhgvWfCWSoCCIYJ52peM6logt75sdH+o8EeyoN5uUb+F4yneVLjY6er1KHMQuD
-        ZIE6+9Ho30smAA68XGOKDi9fY5gtOAosOHn0PriU8g+U0Rd6rYSyOL7kTQAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/Views/StatsDisplay.Designer.cs
+++ b/Views/StatsDisplay.Designer.cs
@@ -23,83 +23,90 @@
         /// the contents of this method with the code editor.
         /// </summary>
         private void InitializeComponent() {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(StatsDisplay));
-            this.graph = new FallGuysStats.Graph();
-            this.chkWins = new System.Windows.Forms.CheckBox();
-            this.chkFinals = new System.Windows.Forms.CheckBox();
-            this.chkShows = new System.Windows.Forms.CheckBox();
-            ((System.ComponentModel.ISupportInitialize)(this.graph)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // graph
-            // 
-            this.graph.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+      System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(StatsDisplay));
+      this.chkWins = new System.Windows.Forms.CheckBox();
+      this.chkFinals = new System.Windows.Forms.CheckBox();
+      this.chkShows = new System.Windows.Forms.CheckBox();
+      this.graph = new FallGuysStats.Graph();
+      ((System.ComponentModel.ISupportInitialize)(this.graph)).BeginInit();
+      this.SuspendLayout();
+      // 
+      // chkWins
+      // 
+      this.chkWins.AutoSize = true;
+      this.chkWins.Location = new System.Drawing.Point(18, 20);
+      this.chkWins.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkWins.Name = "chkWins";
+      this.chkWins.Size = new System.Drawing.Size(70, 24);
+      this.chkWins.TabIndex = 1;
+      this.chkWins.Text = "Wins";
+      this.chkWins.UseVisualStyleBackColor = true;
+      this.chkWins.CheckedChanged += new System.EventHandler(this.chkWins_CheckedChanged);
+      // 
+      // chkFinals
+      // 
+      this.chkFinals.AutoSize = true;
+      this.chkFinals.Location = new System.Drawing.Point(102, 20);
+      this.chkFinals.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkFinals.Name = "chkFinals";
+      this.chkFinals.Size = new System.Drawing.Size(77, 24);
+      this.chkFinals.TabIndex = 2;
+      this.chkFinals.Text = "Finals";
+      this.chkFinals.UseVisualStyleBackColor = true;
+      this.chkFinals.CheckedChanged += new System.EventHandler(this.chkFinals_CheckedChanged);
+      // 
+      // chkShows
+      // 
+      this.chkShows.AutoSize = true;
+      this.chkShows.Location = new System.Drawing.Point(190, 20);
+      this.chkShows.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.chkShows.Name = "chkShows";
+      this.chkShows.Size = new System.Drawing.Size(83, 24);
+      this.chkShows.TabIndex = 3;
+      this.chkShows.Text = "Shows";
+      this.chkShows.UseVisualStyleBackColor = true;
+      this.chkShows.CheckedChanged += new System.EventHandler(this.chkShows_CheckedChanged);
+      // 
+      // graph
+      // 
+      this.graph.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.graph.BackColor = System.Drawing.Color.Transparent;
-            this.graph.BackgroundColor = System.Drawing.Color.Transparent;
-            this.graph.ErrorImage = null;
-            this.graph.InitialImage = null;
-            this.graph.Location = new System.Drawing.Point(0, 36);
-            this.graph.Name = "graph";
-            this.graph.Opacity = 0;
-            this.graph.Size = new System.Drawing.Size(614, 502);
-            this.graph.TabIndex = 0;
-            this.graph.TabStop = false;
-            // 
-            // chkWins
-            // 
-            this.chkWins.AutoSize = true;
-            this.chkWins.Location = new System.Drawing.Point(12, 13);
-            this.chkWins.Name = "chkWins";
-            this.chkWins.Size = new System.Drawing.Size(50, 17);
-            this.chkWins.TabIndex = 1;
-            this.chkWins.Text = "Wins";
-            this.chkWins.UseVisualStyleBackColor = true;
-            this.chkWins.CheckedChanged += new System.EventHandler(this.chkWins_CheckedChanged);
-            // 
-            // chkFinals
-            // 
-            this.chkFinals.AutoSize = true;
-            this.chkFinals.Location = new System.Drawing.Point(68, 13);
-            this.chkFinals.Name = "chkFinals";
-            this.chkFinals.Size = new System.Drawing.Size(53, 17);
-            this.chkFinals.TabIndex = 2;
-            this.chkFinals.Text = "Finals";
-            this.chkFinals.UseVisualStyleBackColor = true;
-            this.chkFinals.CheckedChanged += new System.EventHandler(this.chkFinals_CheckedChanged);
-            // 
-            // chkShows
-            // 
-            this.chkShows.AutoSize = true;
-            this.chkShows.Location = new System.Drawing.Point(127, 13);
-            this.chkShows.Name = "chkShows";
-            this.chkShows.Size = new System.Drawing.Size(58, 17);
-            this.chkShows.TabIndex = 3;
-            this.chkShows.Text = "Shows";
-            this.chkShows.UseVisualStyleBackColor = true;
-            this.chkShows.CheckedChanged += new System.EventHandler(this.chkShows_CheckedChanged);
-            // 
-            // StatsDisplay
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(242)))), ((int)(((byte)(251)))));
-            this.ClientSize = new System.Drawing.Size(614, 538);
-            this.Controls.Add(this.chkShows);
-            this.Controls.Add(this.chkFinals);
-            this.Controls.Add(this.chkWins);
-            this.Controls.Add(this.graph);
-            this.ForeColor = System.Drawing.Color.Black;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Name = "StatsDisplay";
-            this.ShowInTaskbar = false;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Stats Display";
-            this.Load += new System.EventHandler(this.StatsDisplay_Load);
-            ((System.ComponentModel.ISupportInitialize)(this.graph)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+      this.graph.BackColor = System.Drawing.Color.Transparent;
+      this.graph.BackgroundColor = System.Drawing.Color.Transparent;
+      this.graph.ErrorImage = null;
+      this.graph.InitialImage = null;
+      this.graph.Location = new System.Drawing.Point(0, 55);
+      this.graph.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.graph.Name = "graph";
+      this.graph.Opacity = 0;
+      this.graph.Size = new System.Drawing.Size(921, 772);
+      this.graph.TabIndex = 0;
+      this.graph.TabStop = false;
+      // 
+      // StatsDisplay
+      // 
+      this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(242)))), ((int)(((byte)(251)))));
+      this.ClientSize = new System.Drawing.Size(921, 828);
+      this.Controls.Add(this.chkShows);
+      this.Controls.Add(this.chkFinals);
+      this.Controls.Add(this.chkWins);
+      this.Controls.Add(this.graph);
+      this.ForeColor = System.Drawing.Color.Black;
+      this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+      this.KeyPreview = true;
+      this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.Name = "StatsDisplay";
+      this.ShowInTaskbar = false;
+      this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+      this.Text = "Stats Display";
+      this.Load += new System.EventHandler(this.StatsDisplay_Load);
+      this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.StatsDisplay_KeyDown);
+      ((System.ComponentModel.ISupportInitialize)(this.graph)).EndInit();
+      this.ResumeLayout(false);
+      this.PerformLayout();
 
         }
 

--- a/Views/StatsDisplay.cs
+++ b/Views/StatsDisplay.cs
@@ -29,5 +29,11 @@ namespace FallGuysStats {
             graph.YColumns[3] = chkShows.Checked;
             graph.Invalidate();
         }
+
+        private void StatsDisplay_KeyDown(object sender, KeyEventArgs e) {
+            if (e.KeyCode.Equals(Keys.Escape)) {
+                Close();
+            }
+        }
     }
 }


### PR DESCRIPTION
Hi friends, I've recently pulled the repo and made a bunch of little quality of life enhancements that I think would help things out:
 
* Move top labels into a true toolbar to aid in layout management.
* Clicking a level name opens level details like clicking the info icon.
* Clicking elsewhere in the grid toggles percentage display like clicking the win % heading label, so the odd UX path of clicking the "Win %" label to toggle level percentage displays isn't necessary.
* Added a "Grid Display" button to toolbar to explicitly set count vs. percentage displays.
* Pressing escape while viewing Level Details or Stats Display closes the window, i.e., user does not have to click the X or press Alt-F4 to close these sub-screens.
* Refactor some event handlers so they can be triggered from multiple locations more easily, i.e., clicking label, clicking other button, clicking menu item can call the same code from each location for maintainability.
* Added a setting option to ignore the game type when sorting the grid. I frequently want to see what my fastest time is regardless of type, and sorting within types frustrates that.
* Add a toolbar button to launch the Fall Guys game by dynamically finding the steam install folder and locating the game exe within the configured Steam library locations. Add a check to avoid trying to launch a second game process.
* Add settings to manually locate the Fall Guys exe if auto-detection fails.
* Add setting to auto-launch Fall Guys on stats tracker start, so users can just fire up the tracker and end up in the game.
* Add cancel button to settings screen.