### PR TITLE
Fixing issue with new matchmaking

### DIFF
--- a/Entities/LogFileWatcher.cs
+++ b/Entities/LogFileWatcher.cs
@@ -230,10 +230,10 @@ namespace FallGuysStats {
                 logRound.Info.GameDuration = logRound.Duration;
                 logRound.CountingPlayers = true;
                 logRound.Info.IsFinal = logRound.IsFinal || (!logRound.HasIsFinal && LevelStats.SceneToRound.TryGetValue(logRound.Info.SceneName, out string roundName) && LevelStats.ALL.TryGetValue(roundName, out LevelStats stats) && stats.IsFinal);
-            } else if ((index = line.Line.IndexOf("[StateMatchmaking] Begin matchmaking", StringComparison.OrdinalIgnoreCase)) > 0 ||
+            } else if ((index = line.Line.IndexOf("[StateMatchmaking] Begin", StringComparison.OrdinalIgnoreCase)) > 0 ||
                 (index = line.Line.IndexOf("[GameStateMachine] Replacing FGClient.StateMainMenu with FGClient.StatePrivateLobby", StringComparison.OrdinalIgnoreCase)) > 0) {
                 logRound.PrivateLobby = line.Line.IndexOf("StatePrivateLobby") > 0;
-                logRound.CurrentlyInParty = logRound.PrivateLobby || !line.Line.Substring(index + 37).Equals("solo", StringComparison.OrdinalIgnoreCase);
+                logRound.CurrentlyInParty = logRound.PrivateLobby || (line.Line.IndexOf("solo", StringComparison.OrdinalIgnoreCase) > 0);
                 if (logRound.Info != null) {
                     if (logRound.Info.End == DateTime.MinValue) {
                         logRound.Info.End = line.Date;


### PR DESCRIPTION
Fixes #117 

After doing some investigations, I found out that the new matchmaking system is using different messages whenever players are in parties or playing alone.
For instance, when you play alone, this is the line in the logs which is looked for:

[StateMatchmaking] Begin matchmaking solo

But when you play with a party, the logs now print the following:

[StateMatchmaking] Begin party communications

The code still uses the "Begin matchmaking" words to understand a new show is being played.

The solution I found is to look for "[StateMatchmaking] Begin" instead. There was some side effects on the party detection code, but easily fixable.