### PR TITLE
Fixing issues in log parsing

### DIFF
--- a/Entities/LogFileWatcher.cs
+++ b/Entities/LogFileWatcher.cs
@@ -15,9 +15,11 @@ namespace FallGuysStats {
         public LogLine(string line, long offset) {
             Offset = offset;
             Line = line;
-            IsValid = line.IndexOf(':') == 2 && line.IndexOf(':', 3) == 5 && line.IndexOf(':', 6) == 12;
+            bool isValidSemiColon = (line.IndexOf(':') == 2 && line.IndexOf(':', 3) == 5 && line.IndexOf(':', 6) == 12);
+            bool isValidDot = (line.IndexOf('.') == 2 && line.IndexOf('.', 3) == 5 && line.IndexOf(':', 6) == 12);
+            IsValid = isValidSemiColon || isValidDot;
             if (IsValid) {
-                Time = TimeSpan.Parse(line.Substring(0, 12));
+                Time = TimeSpan.ParseExact(line.Substring(0, 12), isValidSemiColon ? "hh\\:mm\\:ss\\.fff" : "hh\\.mm\\.ss\\.fff", null);
             }
         }
 


### PR DESCRIPTION
Fixes #128: issue with logs containing dots instead of semicolons as separators
And also contains a hotfix to an incomplete fix to #117 done previously 