### PR TITLE
Support log format 8.2.0+

### DIFF
--- a/Entities/LogFileRewriter.cs
+++ b/Entities/LogFileRewriter.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+namespace FallGuysStats {
+    public class RewriteLogLine {
+        //public TimeSpan Time { get; } = TimeSpan.Zero;
+        public DateTime Date { get; set; } = DateTime.MinValue;
+        public string Line { get; set; }
+        public bool IsValid { get; set; }
+        public long Offset { get; set; }
+
+        public RewriteLogLine(string line, long offset) {
+            Offset = offset;
+            Line = line;
+            
+            DateTime dateStamp;
+            bool isValidDate = false;
+
+            try {
+                var colonIndex = line.IndexOf(':');
+                isValidDate = !string.IsNullOrWhiteSpace(line) && colonIndex > 0 && DateTime.TryParse(line.Substring(0, colonIndex), out dateStamp);
+            } catch { }
+
+            if (isValidDate) {
+                IsValid = true;
+
+                // Ignoring that some lines have a timestamp after the date,
+                // could cause problems with timestamp-less lines around it 
+                // being presented out of time order
+
+                // Rounding time to 1ms to faithfully mimic the old log format
+                var timeStamp = DateTime.UtcNow.AddTicks(-(DateTime.UtcNow.Ticks % 10));
+                var timeStampString = timeStamp.ToString("HH\\:mm\\:ss\\.fff");
+
+                Date = timeStamp;
+
+                // Modify line to remove leading date
+                Line = Line.Substring(Line.IndexOf(":"));
+                Line = timeStampString + Line;
+                
+            }
+        }
+
+        public override string ToString() {
+            return $"{Line}";
+        }
+    }
+    public class RewriteLogRound {
+        public bool CountingPlayers;
+        public int Players;
+        public bool CurrentlyInParty;
+        public bool PrivateLobby;
+        public bool FindingPosition;
+        public bool IsFinal;
+        public bool HasIsFinal;
+        public string CurrentPlayerID;
+        public int LastPing;
+        public int Duration;
+        public RoundInfo Info;
+    }
+    public class LogFileRewriter {
+        const int UpdateDelay = 50;
+
+        private string filePath;
+        private string newFilePath;
+        private bool running;
+        private bool stop;
+        private Thread watcher;
+
+        public event Action<string> OnError;
+
+        public void Start(string logDirectory, string fileName) {
+            if (running) { return; }
+
+            filePath = Path.Combine(logDirectory, fileName);
+            newFilePath = Path.Combine(logDirectory, "player-withtime.log");
+
+            if (!File.Exists(newFilePath)) {
+                File.Create(newFilePath);
+            } else {
+                // Empty out the player-withtime.log file
+                System.IO.File.WriteAllText(newFilePath, string.Empty);
+            }
+
+            stop = false;
+            watcher = new Thread(ReadLogFile) { IsBackground = true };
+            watcher.Start();
+        }
+
+        public async Task Stop() {
+            stop = true;
+            while (running || watcher == null || watcher.ThreadState == ThreadState.Unstarted) {
+                await Task.Delay(50);
+            }
+            await Task.Factory.StartNew(() => watcher?.Join());
+        }
+
+        private void ReadLogFile() {
+            running = true;
+            List<string> tempLines = new List<string>();
+            DateTime lastDate = DateTime.MinValue;
+            bool completed = false;
+            string currentFilePath = filePath;
+            long offset = 0;
+
+            while (!stop) {
+                try {
+                    if (File.Exists(currentFilePath)) {
+                        using (FileStream fs = new FileStream(currentFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) {
+                            tempLines.Clear();
+
+                            if (offset == 0) {
+                                offset = fs.Length;
+                            }
+
+                            if (fs.Length > offset) {
+                                fs.Seek(offset, SeekOrigin.Begin);
+
+                                LineReader sr = new LineReader(fs);
+                                string line;
+                                DateTime currentDate = lastDate;
+                                while ((line = sr.ReadLine()) != null) {
+                                    
+                                    RewriteLogLine logLine = new RewriteLogLine(line, sr.Position);
+                                    tempLines.Add(logLine.Line);
+
+                                    // [StateGameLoading] Loading game level scene
+                                    int index;
+                                    if ((index = logLine.Line.IndexOf("[StateGameLoading] Loading game level scene", StringComparison.OrdinalIgnoreCase)) > 0) {
+
+                                        // Search player-withtime.log for the "[GlobalGameStateClient].PreStart called at" message. if none found, inject it
+                                        string contentsWithTimeLog = File.ReadAllText(newFilePath);
+                                        if (contentsWithTimeLog.IndexOf("[GlobalGameStateClient].PreStart called at", StringComparison.OrdinalIgnoreCase) < 0) {
+                                            tempLines.Add(String.Format("{0}: [GlobalGameStateClient].PreStart called at {1}  UTC", logLine.Date.ToString("HH\\:mm\\:ss\\.fff"), logLine.Date.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss")));
+                                        }
+                                    }
+
+                                    offset = sr.Position;
+                                }
+                            } else if (offset > fs.Length) {
+                                offset = fs.Length;
+                            }
+                        }
+                    }
+
+                    if (tempLines.Count > 0) {
+                        // Write to the new file
+                        File.AppendAllLines(newFilePath, tempLines, Encoding.UTF8);
+                    }
+
+                } catch (Exception ex) {
+                    OnError?.Invoke(ex.ToString());
+                }
+                Thread.Sleep(UpdateDelay);
+            }
+            running = false;
+        }
+    }
+}

--- a/Entities/LogFileRewriter.cs
+++ b/Entities/LogFileRewriter.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 namespace FallGuysStats {
     public class RewriteLogLine {
-        //public TimeSpan Time { get; } = TimeSpan.Zero;
         public DateTime Date { get; set; } = DateTime.MinValue;
         public string Line { get; set; }
         public bool IsValid { get; set; }
@@ -40,7 +39,6 @@ namespace FallGuysStats {
                 // Modify line to remove leading date
                 Line = Line.Substring(Line.IndexOf(":"));
                 Line = timeStampString + Line;
-                
             }
         }
 

--- a/Entities/LogFileWatcher.cs
+++ b/Entities/LogFileWatcher.cs
@@ -50,6 +50,9 @@ namespace FallGuysStats {
         private bool stop;
         private Thread watcher, parser;
 
+        //TODO Dynamically determine if (real) logs have timestamps
+        public bool LogHasTimestamps = false;
+
         public event Action<List<RoundInfo>> OnParsedLogLines;
         public event Action<List<RoundInfo>> OnParsedLogLinesCurrent;
         public event Action<DateTime> OnNewLogFileDate;
@@ -59,6 +62,9 @@ namespace FallGuysStats {
             if (running) { return; }
 
             filePath = Path.Combine(logDirectory, fileName);
+            if (!LogHasTimestamps) {
+                filePath = Path.Combine(logDirectory, "player-withtime.log");
+            }
             prevFilePath = Path.Combine(logDirectory, Path.GetFileNameWithoutExtension(fileName) + "-prev.log");
             stop = false;
             watcher = new Thread(ReadLogFile) { IsBackground = true };
@@ -82,7 +88,12 @@ namespace FallGuysStats {
             List<LogLine> tempLines = new List<LogLine>();
             DateTime lastDate = DateTime.MinValue;
             bool completed = false;
+            
             string currentFilePath = prevFilePath;
+            if (LogHasTimestamps) {
+                currentFilePath = filePath;
+            }
+            
             long offset = 0;
             while (!stop) {
                 try {

--- a/Entities/LogFileWatcher.cs
+++ b/Entities/LogFileWatcher.cs
@@ -44,14 +44,10 @@ namespace FallGuysStats {
         const int UpdateDelay = 500;
 
         private string filePath;
-        private string prevFilePath;
         private List<LogLine> lines = new List<LogLine>();
         private bool running;
         private bool stop;
         private Thread watcher, parser;
-
-        //TODO Dynamically determine if (real) logs have timestamps
-        public bool LogHasTimestamps = false;
 
         public event Action<List<RoundInfo>> OnParsedLogLines;
         public event Action<List<RoundInfo>> OnParsedLogLinesCurrent;
@@ -61,11 +57,8 @@ namespace FallGuysStats {
         public void Start(string logDirectory, string fileName) {
             if (running) { return; }
 
-            filePath = Path.Combine(logDirectory, fileName);
-            if (!LogHasTimestamps) {
-                filePath = Path.Combine(logDirectory, "player-withtime.log");
-            }
-            prevFilePath = Path.Combine(logDirectory, Path.GetFileNameWithoutExtension(fileName) + "-prev.log");
+            filePath = Path.Combine(logDirectory, "player-withtime.log");
+            
             stop = false;
             watcher = new Thread(ReadLogFile) { IsBackground = true };
             watcher.Start();
@@ -89,10 +82,7 @@ namespace FallGuysStats {
             DateTime lastDate = DateTime.MinValue;
             bool completed = false;
             
-            string currentFilePath = prevFilePath;
-            if (LogHasTimestamps) {
-                currentFilePath = filePath;
-            }
+            string currentFilePath = filePath;
             
             long offset = 0;
             while (!stop) {

--- a/FallGuysStats.csproj
+++ b/FallGuysStats.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Entities\Json.cs" />
     <Compile Include="Entities\LevelType.cs" />
     <Compile Include="Entities\LineReader.cs" />
+    <Compile Include="Entities\LogFileRewriter.cs" />
     <Compile Include="Entities\StatSummary.cs" />
     <Compile Include="Entities\UserSettings.cs" />
     <Compile Include="Views\LevelDetails.cs">

--- a/Views/Stats.cs
+++ b/Views/Stats.cs
@@ -83,21 +83,6 @@ namespace FallGuysStats {
 
             gridDetails.DataSource = StatDetails;
 
-            if (!File.Exists("data-pre8_2_0-backup.db") || !File.Exists("data.db")) {
-                
-                string initial8_2Message = "As of Fall Guys 8.2.0, essential timing info has been removed from the logs. This version of the stat tracker reconstructs the timestamps. Round completion times should be close to correct (within ~0.1 seconds)" + Environment.NewLine + Environment.NewLine + "Please make sure the stat tracker is running BEFORE starting a show!";
-
-                if (File.Exists("data.db")) {
-                    File.Copy("data.db", "data-pre8_2_0-backup.db");
-                    initial8_2Message += Environment.NewLine + Environment.NewLine + "A backup of the existing database has been written to data-pre8_2_0-backup.db";
-                } else {
-                    // Create blank data-pre8_2_0-backup.db to prevent additional messages
-                    File.Create("data-pre8_2_0-backup.db").Dispose();
-                }
-
-                MessageBox.Show(this, initial8_2Message, "Info", MessageBoxButtons.OK, MessageBoxIcon.Information);
-            }
-
             StatsDB = new LiteDatabase(@"data.db");
             StatsDB.Pragma("UTC_DATE", true);
             RoundDetails = StatsDB.GetCollection<RoundInfo>("RoundDetails");
@@ -812,21 +797,6 @@ namespace FallGuysStats {
 
                             if (info == null && stat.Start > lastAddedShow) {
                                 
-                                // Commenting out because with new log only using logs read at realtime,
-                                // We always want the data to import
-
-                                //if (stat.ShowEnd < startupTime && askedPreviousShows == 0) {
-                                //    if (MessageBox.Show(this, "There are previous shows not in your current stats. Do you wish to add these to your stats?", "Previous Shows", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes) {
-                                //        askedPreviousShows = 1;
-                                //    } else {
-                                //        askedPreviousShows = 2;
-                                //    }
-                                //}
-
-                                //if (stat.ShowEnd < startupTime && askedPreviousShows == 2) {
-                                //    continue;
-                                //}
-
                                 if (stat.Round == 1) {
                                     nextShowID++;
                                     lastAddedShow = stat.Start;


### PR DESCRIPTION
As timestamps have been removed from the logs, this update creates timestamps in real-time and writes the log to a new file called player-withtime.log (LogFileRewriter.cs). LogFileWatcher.cs has been changed to only read this new file. As we need to write timestamps in real-time, I've removed the part in Stats.cs that prompts to load older data.

As this generates timestamps in real-time, the timing data is no longer exact. In my testing, it's pretty close (within 0.1 seconds).

Several people have been testing this code and I believe there are no major issues. There was an issue that I could replicate where some shots intermittingly would not find their way to the database, but I haven't been able to recreate that after applying a bug fix on 2022/10/31.

As part of my test releases, I added code that made a backup of the database, and showed a MessageBox upon running the first time. These are not part of this pull request.

I have tested this code against the client update 8.3.0 and it is working.