### PR TITLE
Consider MM/dd/yyyy format when identifying valid log entries

### DIFF
--- a/Entities/LogFileRewriter.cs
+++ b/Entities/LogFileRewriter.cs
@@ -21,6 +21,9 @@ namespace FallGuysStats {
             try {
                 var colonIndex = line.IndexOf(':');
                 isValidDate = !string.IsNullOrWhiteSpace(line) && colonIndex > 0 && DateTime.TryParse(line.Substring(0, colonIndex), out dateStamp);
+                if (!isValidDate) {
+                    isValidDate = !string.IsNullOrWhiteSpace(line) && colonIndex > 0 && DateTime.TryParseExact(line.Substring(0, colonIndex), "MM/dd/yyyy", new System.Globalization.CultureInfo("en-US"), System.Globalization.DateTimeStyles.None, out dateStamp);
+                }
             } catch { }
 
             if (isValidDate) {


### PR DESCRIPTION
The Fall Guys log has started writing datestamps in different formats if your computer's regional format is set to something other than MM/dd/yyyy. For log entries not happening during a game, Fall Guys writes the date in the format of the PC. During a game, it always uses the format MM/dd/yyyy.

This update simply checks lines to look for dates in either format. Either way, the date itself gets overwritten with a timestamp (to match the pre-8.2.0 format)