### PR TITLE
Bug fix

### DIFF
--- a/Entities/LogFileWatcher.cs
+++ b/Entities/LogFileWatcher.cs
@@ -498,7 +498,7 @@ namespace FallGuysStats {
                          && (roundId.EndsWith("_opener_4", StringComparison.OrdinalIgnoreCase)
                              || roundId.IndexOf("_final", StringComparison.OrdinalIgnoreCase) != -1))
 
-                     // "Ranked" Shows
+                     // "Ranked"
                      || (roundId.StartsWith("ranked_", StringComparison.OrdinalIgnoreCase)
                          && roundId.EndsWith("_final", StringComparison.OrdinalIgnoreCase));
         }

--- a/Views/Stats.cs
+++ b/Views/Stats.cs
@@ -1621,9 +1621,29 @@ namespace FallGuysStats {
         }
         
         private void UpdateDatabaseVersion() {
-            int lastVersion = 116;
+            int lastVersion = 117;
             for (int version = this.CurrentSettings.Version; version < lastVersion; version++) {
                 switch (version) {
+                    case 116: {
+                            DateTime dateCond = new DateTime(2025, 4, 1, 9, 0, 0, DateTimeKind.Utc);
+                            List<RoundInfo> roundInfoList = (from ri in this.RoundDetails.FindAll()
+                                                             where string.Equals(ri.ShowNameId, "knockout_mode") && ri.Start >= dateCond
+                                                             select ri).ToList();
+                            
+                            foreach (RoundInfo ri in roundInfoList) {
+                                if ((ri.Name.StartsWith("ranked_") && ri.Name.EndsWith("_final"))
+                                     || string.Equals(ri.Name, "round_floor_fall")
+                                     || string.Equals(ri.Name, "round_kraken_attack")
+                                     || string.Equals(ri.Name, "round_tunnel_final")
+                                     || string.Equals(ri.Name, "round_blastball_arenasurvival_symphony_launch_show")) {
+                                    ri.IsFinal = true;
+                                }
+                            }
+                            this.StatsDB.BeginTrans();
+                            this.RoundDetails.Update(roundInfoList);
+                            this.StatsDB.Commit();
+                            break;
+                        }
                     case 115: {
                             List<RoundInfo> roundInfoList = (from ri in this.RoundDetails.FindAll()
                                                              where string.Equals(ri.ShowNameId, "showcase_fp18")


### PR DESCRIPTION
Rounds name for "Knockout" (Not ranked) is now starting with "ranked_" instead of "knockout_" (Certified MediaTonic Moment™)