### PR TITLE
Fix show name sorting to properly group entries by ShowID

### DIFF
--- a/Views/LevelDetails.cs
+++ b/Views/LevelDetails.cs
@@ -862,7 +862,7 @@ namespace FallGuysStats {
                         string showNameIdOne = Multilingual.GetShowName(one.ShowNameId) ?? @" ";
                         string showNameIdTwo = Multilingual.GetShowName(two.ShowNameId) ?? @" ";
                         int showNameIdCompare = showNameIdOne.CompareTo(showNameIdTwo);
-                        return showNameIdCompare != 0 ? showNameIdCompare : roundCompare;
+                        return showNameIdCompare != 0 ? showNameIdCompare : showCompare == 0 ? roundCompare : showCompare;
                     case "Round":
                         roundCompare = one.Round.CompareTo(two.Round);
                         return roundCompare != 0 ? roundCompare : showCompare;


### PR DESCRIPTION
When sorting by show name, entries with the same show name were being scattered by round number instead of being grouped together. Changed the secondary sort to use showCompare (matching the pattern used by all other column sorts) so entries with the same show name are now properly grouped by ShowID.

Fixes sorting behavior in the Shows/Rounds stats list.